### PR TITLE
Rename 'Dashboard' context to 'Submissions'

### DIFF
--- a/lib/adoptoposs/accounts/user.ex
+++ b/lib/adoptoposs/accounts/user.ex
@@ -2,7 +2,7 @@ defmodule Adoptoposs.Accounts.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Adoptoposs.{Accounts, Dashboard, Communication, Tags}
+  alias Adoptoposs.{Accounts, Submissions, Communication, Tags}
 
   schema "users" do
     field :avatar_url, :string
@@ -14,7 +14,7 @@ defmodule Adoptoposs.Accounts.User do
     field :username, :string
 
     embeds_one :settings, Accounts.Settings, on_replace: :update
-    has_many :projects, Dashboard.Project
+    has_many :projects, Submissions.Project
     has_many :interests, Communication.Interest, foreign_key: :creator_id
     has_many :tag_subscriptions, Tags.TagSubscription, on_delete: :delete_all
     has_many :tags, through: [:tag_subscriptions, :tag]

--- a/lib/adoptoposs/communication.ex
+++ b/lib/adoptoposs/communication.ex
@@ -8,7 +8,7 @@ defmodule Adoptoposs.Communication do
   alias Adoptoposs.Repo
   alias Adoptoposs.Communication.{Interest, Policy}
   alias Adoptoposs.Accounts.User
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
 
   defdelegate authorize(action, user, params), to: Policy
 

--- a/lib/adoptoposs/communication/interest.ex
+++ b/lib/adoptoposs/communication/interest.ex
@@ -2,13 +2,13 @@ defmodule Adoptoposs.Communication.Interest do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Adoptoposs.{Accounts, Dashboard}
+  alias Adoptoposs.{Accounts, Submissions}
 
   schema "interests" do
     field :message, :string
 
     belongs_to :creator, Accounts.User, foreign_key: :creator_id
-    belongs_to :project, Dashboard.Project
+    belongs_to :project, Submissions.Project
 
     timestamps()
   end

--- a/lib/adoptoposs/communication/policy.ex
+++ b/lib/adoptoposs/communication/policy.ex
@@ -2,7 +2,7 @@ defmodule Adoptoposs.Communication.Policy do
   @behaviour Bodyguard.Policy
 
   alias Adoptoposs.Accounts.User
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
 
   def authorize(:create_interest, %User{id: user_id}, %Project{user_id: user_id}), do: :error
   def authorize(:create_interest, %User{}, %Project{}), do: :ok

--- a/lib/adoptoposs/search.ex
+++ b/lib/adoptoposs/search.ex
@@ -7,7 +7,7 @@ defmodule Adoptoposs.Search do
   import Ecto.Query, warn: false
 
   alias Adoptoposs.Repo
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
   alias Adoptoposs.Tags.Tag
 
   def find_projects(query, offset: offset, limit: limit) do

--- a/lib/adoptoposs/submissions.ex
+++ b/lib/adoptoposs/submissions.ex
@@ -1,6 +1,6 @@
-defmodule Adoptoposs.Dashboard do
+defmodule Adoptoposs.Submissions do
   @moduledoc """
-  The Dashboard context.
+  The Submissions context.
   """
 
   import Ecto.Query, warn: false
@@ -8,7 +8,7 @@ defmodule Adoptoposs.Dashboard do
   alias Adoptoposs.Repo
   alias Adoptoposs.Network.Repository
   alias Adoptoposs.Accounts.User
-  alias Adoptoposs.Dashboard.{Project, Policy}
+  alias Adoptoposs.Submissions.{Project, Policy}
 
   defdelegate authorize(action, user, params), to: Policy
 

--- a/lib/adoptoposs/submissions/policy.ex
+++ b/lib/adoptoposs/submissions/policy.ex
@@ -1,8 +1,8 @@
-defmodule Adoptoposs.Dashboard.Policy do
+defmodule Adoptoposs.Submissions.Policy do
   @behaviour Bodyguard.Policy
 
   alias Adoptoposs.Accounts.User
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
 
   def authorize(action, %User{id: user_id}, %Project{user_id: user_id})
       when action in [:show_project, :update_project, :delete_project],

--- a/lib/adoptoposs/submissions/project.ex
+++ b/lib/adoptoposs/submissions/project.ex
@@ -1,4 +1,4 @@
-defmodule Adoptoposs.Dashboard.Project do
+defmodule Adoptoposs.Submissions.Project do
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/adoptoposs/tags/tag.ex
+++ b/lib/adoptoposs/tags/tag.ex
@@ -2,7 +2,7 @@ defmodule Adoptoposs.Tags.Tag do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Adoptoposs.{Dashboard, Tags}
+  alias Adoptoposs.{Submissions, Tags}
 
   schema "tags" do
     field :color, :string
@@ -11,7 +11,7 @@ defmodule Adoptoposs.Tags.Tag do
 
     has_many :tag_subscriptions, Tags.TagSubscription, on_delete: :delete_all
     has_many :users, through: [:tag_subscriptions, :user]
-    has_many :projects, Dashboard.Project, foreign_key: :language_id
+    has_many :projects, Submissions.Project, foreign_key: :language_id
 
     timestamps()
   end

--- a/lib/adoptoposs_web/live/interest_component.ex
+++ b/lib/adoptoposs_web/live/interest_component.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.InterestComponent do
   use AdoptopossWeb, :live_component
 
-  alias Adoptoposs.{Accounts, Communication, Dashboard}
+  alias Adoptoposs.{Accounts, Communication, Submissions}
   alias Adoptoposs.Communication.Interest
   alias AdoptopossWeb.Mailer
 
@@ -23,7 +23,7 @@ defmodule AdoptopossWeb.InterestComponent do
 
   def handle_event("submit", %{"message" => message}, %{assigns: assigns} = socket) do
     user = Accounts.get_user!(assigns.user_id)
-    project = Dashboard.get_project!(assigns.project_id)
+    project = Submissions.get_project!(assigns.project_id)
     attrs = %{creator_id: user.id, project_id: project.id, message: message}
 
     with :ok <- Bodyguard.permit(Communication, :create_interest, user, project),

--- a/lib/adoptoposs_web/live/landing_page_live.ex
+++ b/lib/adoptoposs_web/live/landing_page_live.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.LandingPageLive do
   use AdoptopossWeb, :live_view
 
-  alias Adoptoposs.{Accounts, Dashboard, Communication}
+  alias Adoptoposs.{Accounts, Submissions, Communication}
   alias AdoptopossWeb.LandingPageView
 
   @doc """
@@ -35,6 +35,6 @@ defmodule AdoptopossWeb.LandingPageLive do
   end
 
   defp put_assigns(socket, _) do
-    assign(socket, projects: Dashboard.list_projects(limit: 6))
+    assign(socket, projects: Submissions.list_projects(limit: 6))
   end
 end

--- a/lib/adoptoposs_web/live/project_live/index.ex
+++ b/lib/adoptoposs_web/live/project_live/index.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.ProjectLive.Index do
   use AdoptopossWeb, :live_view
 
-  alias Adoptoposs.{Dashboard, Accounts}
+  alias Adoptoposs.{Submissions, Accounts}
   alias AdoptopossWeb.ProjectView
 
   def render(assigns) do
@@ -26,11 +26,11 @@ defmodule AdoptopossWeb.ProjectLive.Index do
 
   def handle_event("update", %{"id" => id, "message" => description}, socket) do
     user = Accounts.get_user!(socket.assigns.user_id)
-    project = Dashboard.get_project!(id)
+    project = Submissions.get_project!(id)
 
-    with :ok <- Bodyguard.permit(Dashboard, :update_project, user, project),
-         {:ok, _project} <- Dashboard.update_project(project, %{description: description}) do
-      projects = Dashboard.list_projects(user)
+    with :ok <- Bodyguard.permit(Submissions, :update_project, user, project),
+         {:ok, _project} <- Submissions.update_project(project, %{description: description}) do
+      projects = Submissions.list_projects(user)
       {:noreply, assign(socket, projects: projects, edit_id: nil)}
     else
       {:error, _} -> {:noreply, socket}
@@ -47,10 +47,10 @@ defmodule AdoptopossWeb.ProjectLive.Index do
 
   def handle_event("remove", %{"id" => id}, socket) do
     user = %Accounts.User{id: socket.assigns.user_id}
-    project = Dashboard.get_project!(id)
+    project = Submissions.get_project!(id)
 
-    with :ok <- Bodyguard.permit(Dashboard, :delete_project, user, project),
-         {:ok, project} <- Dashboard.delete_project(project) do
+    with :ok <- Bodyguard.permit(Submissions, :delete_project, user, project),
+         {:ok, project} <- Submissions.delete_project(project) do
       projects = socket.assigns.projects |> Enum.drop_while(&(&1.id == project.id))
       {:noreply, assign(socket, projects: projects)}
     else
@@ -63,7 +63,7 @@ defmodule AdoptopossWeb.ProjectLive.Index do
     projects =
       user_id
       |> Accounts.get_user!()
-      |> Dashboard.list_projects()
+      |> Submissions.list_projects()
 
     assign(socket, projects: projects)
   end

--- a/lib/adoptoposs_web/live/project_live/show.ex
+++ b/lib/adoptoposs_web/live/project_live/show.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.ProjectLive.Show do
   use AdoptopossWeb, :live_view
 
-  alias Adoptoposs.{Accounts, Dashboard}
+  alias Adoptoposs.{Accounts, Submissions}
   alias AdoptopossWeb.{ProjectView, ProjectLive}
 
   def render(assigns) do
@@ -10,9 +10,9 @@ defmodule AdoptopossWeb.ProjectLive.Show do
 
   def mount(%{"id" => id}, %{"user_id" => user_id}, socket) do
     user = Accounts.get_user!(user_id)
-    project = Dashboard.get_project!(id, preload: [interests: [:creator, project: [:user]]])
+    project = Submissions.get_project!(id, preload: [interests: [:creator, project: [:user]]])
 
-    with :ok <- Bodyguard.permit(Dashboard, :show_project, user, project) do
+    with :ok <- Bodyguard.permit(Submissions, :show_project, user, project) do
       {:ok, assign(socket, user_id: user_id, project: project)}
     else
       {:error, _} ->

--- a/lib/adoptoposs_web/live/repo_component.ex
+++ b/lib/adoptoposs_web/live/repo_component.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.RepoComponent do
   use AdoptopossWeb, :live_component
 
-  alias Adoptoposs.{Dashboard, Tags}
+  alias Adoptoposs.{Submissions, Tags}
 
   def render(assigns) do
     AdoptopossWeb.RepoView.render("repo.html", assigns)
@@ -20,7 +20,7 @@ defmodule AdoptopossWeb.RepoComponent do
     tag = Tags.get_tag_by_name!(repository.language.name)
     attrs = %{user_id: user_id, language_id: tag.id, description: description}
 
-    case Dashboard.create_project(repository, attrs) do
+    case Submissions.create_project(repository, attrs) do
       {:ok, _project} ->
         {:noreply, assign(socket, submitted: true, to_be_submitted: nil)}
 

--- a/lib/adoptoposs_web/live/repo_live.ex
+++ b/lib/adoptoposs_web/live/repo_live.ex
@@ -2,7 +2,7 @@ defmodule AdoptopossWeb.RepoLive do
   use AdoptopossWeb, :live_view
 
   alias AdoptopossWeb.{Endpoint, RepoView}
-  alias Adoptoposs.{Accounts, Network, Dashboard}
+  alias Adoptoposs.{Accounts, Network, Submissions}
   alias Adoptoposs.Network.Organization
 
   @orga_limit 25
@@ -51,7 +51,7 @@ defmodule AdoptopossWeb.RepoLive do
     organization = %Organization{id: user.username, name: user.name, avatar_url: user.avatar_url}
     organizations = [organization | organizations]
 
-    projects = Dashboard.list_projects(user)
+    projects = Submissions.list_projects(user)
 
     assign(socket, %{
       token: sign_token(token, provider),
@@ -65,7 +65,7 @@ defmodule AdoptopossWeb.RepoLive do
 
   defp update_selected(socket, organization_id) do
     organization = socket.assigns.organizations |> Enum.find(&(&1.id == organization_id))
-    projects = Dashboard.list_projects(%Accounts.User{id: socket.assigns.user_id})
+    projects = Submissions.list_projects(%Accounts.User{id: socket.assigns.user_id})
     submitted_repos = projects |> Enum.map(& &1.repo_id)
 
     socket

--- a/lib/adoptoposs_web/views/interest_view.ex
+++ b/lib/adoptoposs_web/views/interest_view.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.InterestView do
   use AdoptopossWeb, :view
 
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
   alias Adoptoposs.Communication.Interest
 
   @doc """

--- a/lib/adoptoposs_web/views/project_view.ex
+++ b/lib/adoptoposs_web/views/project_view.ex
@@ -1,7 +1,7 @@
 defmodule AdoptopossWeb.ProjectView do
   use AdoptopossWeb, :view
 
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
 
   def can_be_contacted?(%Project{user_id: user_id}, user_id), do: false
   def can_be_contacted?(nil, _), do: false

--- a/lib/adoptoposs_web/views/shared_view.ex
+++ b/lib/adoptoposs_web/views/shared_view.ex
@@ -2,7 +2,7 @@ defmodule AdoptopossWeb.SharedView do
   use AdoptopossWeb, :view
 
   alias Adoptoposs.Network.Repository
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions.Project
 
   def project_url(%Project{} = project), do: project.data["url"]
   def project_url(%Repository{} = project), do: project.url

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -10,7 +10,7 @@
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
 
-alias Adoptoposs.{Dashboard, Tags}
+alias Adoptoposs.{Submissions, Tags}
 
 Faker.start()
 
@@ -56,7 +56,7 @@ defmodule Adoptoposs.Seeds do
   end
 end
 
-if Enum.empty?(Dashboard.list_projects(limit: 1)) do
+if Enum.empty?(Submissions.list_projects(limit: 1)) do
   Adoptoposs.Seeds.create_projects(2000)
 else
   IO.puts("The database is not empty – skipping seed.")

--- a/test/adoptoposs/submissions_test.exs
+++ b/test/adoptoposs/submissions_test.exs
@@ -1,56 +1,58 @@
-defmodule Adoptoposs.DashboardTest do
+defmodule Adoptoposs.SubmissionsTest do
   use Adoptoposs.DataCase
 
   import Adoptoposs.Factory
 
-  alias Adoptoposs.Dashboard
+  alias Adoptoposs.Submissions
 
   describe "policy" do
     test "update_project is permitted for own projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: user.id)
 
-      assert :ok = Bodyguard.permit(Dashboard, :update_project, user, project)
+      assert :ok = Bodyguard.permit(Submissions, :update_project, user, project)
     end
 
     test "update_project is forbidden for other user’s projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: 2)
 
-      assert {:error, :unauthorized} = Bodyguard.permit(Dashboard, :update_project, user, project)
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Submissions, :update_project, user, project)
     end
 
     test "delete_project is permitted for own projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: user.id)
 
-      assert :ok = Bodyguard.permit(Dashboard, :delete_project, user, project)
+      assert :ok = Bodyguard.permit(Submissions, :delete_project, user, project)
     end
 
     test "delete_project is forbidden for other user’s projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: 2)
 
-      assert {:error, :unauthorized} = Bodyguard.permit(Dashboard, :delete_project, user, project)
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Submissions, :delete_project, user, project)
     end
 
     test "show_project is permitted for own projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: user.id)
 
-      assert :ok = Bodyguard.permit(Dashboard, :show_project, user, project)
+      assert :ok = Bodyguard.permit(Submissions, :show_project, user, project)
     end
 
     test "show_project is forbidden for other user’s projects" do
       user = build(:user, id: 1)
       project = build(:project, user_id: 2)
 
-      assert {:error, :unauthorized} = Bodyguard.permit(Dashboard, :show_project, user, project)
+      assert {:error, :unauthorized} = Bodyguard.permit(Submissions, :show_project, user, project)
     end
   end
 
   describe "project" do
-    alias Adoptoposs.Dashboard.Project
+    alias Adoptoposs.Submissions.Project
     alias Adoptoposs.Network.Repository
     alias Adoptoposs.Tags.Tag
 
@@ -58,7 +60,7 @@ defmodule Adoptoposs.DashboardTest do
       insert(:project)
       other_project = insert(:project)
 
-      projects = Dashboard.list_projects(limit: 1)
+      projects = Submissions.list_projects(limit: 1)
       assert projects |> Enum.map(& &1.id) == [other_project.id]
 
       [project | _] = projects
@@ -67,35 +69,35 @@ defmodule Adoptoposs.DashboardTest do
 
     test "list_projects/1 returns a user's projects" do
       project = insert(:project)
-      projects = Dashboard.list_projects(project.user)
+      projects = Submissions.list_projects(project.user)
       assert projects |> Enum.map(& &1.id) == [project.id]
       assert %Tag{} = List.first(projects).language
 
       user = insert(:user)
-      assert Dashboard.list_projects(user) == []
+      assert Submissions.list_projects(user) == []
     end
 
     test "get_project!/1 return the project with the given id" do
       project = insert(:project)
-      assert Dashboard.get_project!(project.id).id == project.id
+      assert Submissions.get_project!(project.id).id == project.id
     end
 
     test "get_project!/1 raises error when the project does not exist" do
       assert_raise Ecto.NoResultsError, fn ->
-        Dashboard.get_project!(-1)
+        Submissions.get_project!(-1)
       end
     end
 
     test "get_user_project/2 returns the project with given id" do
       user = insert(:user)
       project = insert(:project, user: user)
-      assert Dashboard.get_user_project(user, project.id).id == project.id
+      assert Submissions.get_user_project(user, project.id).id == project.id
     end
 
     test "get_user_project/2 returns nil for a non-user project" do
       user = insert(:user)
       project = insert(:project)
-      refute Dashboard.get_user_project(user, project.id)
+      refute Submissions.get_user_project(user, project.id)
     end
 
     test "create_project/2 with valid data creates a project" do
@@ -105,7 +107,7 @@ defmodule Adoptoposs.DashboardTest do
       description = "description"
       attrs = %{user_id: user_id, description: description, language_id: tag_id}
 
-      assert {:ok, project} = Dashboard.create_project(repository, attrs)
+      assert {:ok, project} = Submissions.create_project(repository, attrs)
 
       assert project = %Project{
                description: description,
@@ -116,7 +118,7 @@ defmodule Adoptoposs.DashboardTest do
     end
 
     test "create_project/2 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Dashboard.create_project(%Repository{})
+      assert {:error, %Ecto.Changeset{}} = Submissions.create_project(%Repository{})
     end
 
     test "create_project/2 converts unique_constraint on user and project to error" do
@@ -126,7 +128,7 @@ defmodule Adoptoposs.DashboardTest do
       insert(:project, user: user, language: tag, repo_id: repository.id)
       attrs = %{user_id: user.id, language_id: tag.id}
 
-      assert {:error, changeset} = Dashboard.create_project(repository, attrs)
+      assert {:error, changeset} = Submissions.create_project(repository, attrs)
       assert assert [{:project, {"has already been taken", _}}] = changeset.errors
     end
 
@@ -135,7 +137,7 @@ defmodule Adoptoposs.DashboardTest do
       new_description = "new" <> project.description
       attrs = %{description: new_description}
 
-      assert {:ok, %Project{} = project} = Dashboard.update_project(project, attrs)
+      assert {:ok, %Project{} = project} = Submissions.update_project(project, attrs)
       assert project.description == new_description
     end
 
@@ -143,19 +145,19 @@ defmodule Adoptoposs.DashboardTest do
       project = insert(:project)
       attrs = %{description: nil}
 
-      assert {:error, %Ecto.Changeset{}} = Dashboard.update_project(project, attrs)
-      assert project.id == Dashboard.get_user_project(project.user, project.id).id
+      assert {:error, %Ecto.Changeset{}} = Submissions.update_project(project, attrs)
+      assert project.id == Submissions.get_user_project(project.user, project.id).id
     end
 
     test "delete_project/1 deletes the passed project" do
       project = insert(:project)
-      assert {:ok, %Project{}} = Dashboard.delete_project(project)
-      refute Dashboard.get_user_project(project.user, project.id)
+      assert {:ok, %Project{}} = Submissions.delete_project(project)
+      refute Submissions.get_user_project(project.user, project.id)
     end
 
     test "change_project/1 returns a project changeset" do
       project = insert(:project)
-      assert %Ecto.Changeset{} = Dashboard.change_project(project)
+      assert %Ecto.Changeset{} = Submissions.change_project(project)
     end
   end
 end

--- a/test/adoptoposs_web/live/project_live_test.exs
+++ b/test/adoptoposs_web/live/project_live_test.exs
@@ -4,8 +4,8 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   import Adoptoposs.Factory
 
   alias AdoptopossWeb.ProjectLive
-  alias Adoptoposs.Dashboard
-  alias Adoptoposs.Dashboard.Project
+  alias Adoptoposs.Submissions
+  alias Adoptoposs.Submissions.Project
 
   test "disconnected mount requires authentication on all project routes", %{conn: conn} do
     Enum.each(
@@ -137,6 +137,6 @@ defmodule AdoptopossWeb.ProjectLiveTest do
 
     {:ok, view, _html} = live(conn, Routes.live_path(conn, ProjectLive.Index))
     render_submit(view, :remove, %{id: project.id})
-    assert Dashboard.get_project!(project.id).id == project.id
+    assert Submissions.get_project!(project.id).id == project.id
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -5,7 +5,7 @@ defmodule Adoptoposs.Factory do
 
   use ExMachina.Ecto, repo: Adoptoposs.Repo
 
-  alias Adoptoposs.{Network, Accounts, Dashboard, Communication, Tags}
+  alias Adoptoposs.{Network, Accounts, Submissions, Communication, Tags}
 
   def user_factory do
     %Accounts.User{
@@ -23,7 +23,7 @@ defmodule Adoptoposs.Factory do
   def project_factory do
     repo_id = sequence("repo_id")
 
-    %Dashboard.Project{
+    %Submissions.Project{
       name: sequence("project"),
       language: build(:tag),
       data: build(:repository, id: repo_id),


### PR DESCRIPTION
Because the name "Dashboard" is not appropriate for handling project submission related things.