### PR TITLE
Remove markdown support for in-app user generated texts

### DIFF
--- a/lib/adoptoposs_web/templates/interest/actions.html.leex
+++ b/lib/adoptoposs_web/templates/interest/actions.html.leex
@@ -11,9 +11,7 @@
       <% end %>
     </div>
 
-    <div class="markdown text-gray-700 my-2">
-      <%= {:safe, Earmark.as_html!(@project.description)} %>
-    </div>
+    <div class="whitespace-pre-wrap text-gray-700 my-2"><%= @project.description %></div>
   </div>
 
   <div class="flex flex-wrap flex-row justify-end">

--- a/lib/adoptoposs_web/templates/interest/reply.html.eex
+++ b/lib/adoptoposs_web/templates/interest/reply.html.eex
@@ -3,7 +3,5 @@
 </p>
 
 <blockquote cite="<%= @project_url %>">
-  <em>
-    <%= {:safe, Earmark.as_html!(String.trim(@interest.message))} %>
-  </em>
+  <em style="white-space: pre-wrap;"><%= String.trim(@interest.message) %></em>
 </blockquote>

--- a/lib/adoptoposs_web/templates/landing_page/contacted.html.eex
+++ b/lib/adoptoposs_web/templates/landing_page/contacted.html.eex
@@ -43,11 +43,7 @@
               </div>
             </div>
 
-            <div class="markdown w-full mt-2 md:mt-4">
-              <div class="italic text-pink-900">
-                <%= {:safe, Earmark.as_html!(String.trim(interest.message))} %>
-              </div>
-            </div>
+            <div class="w-full mt-2 md:mt-4 whitespace-pre-wrap italic text-pink-900"><%= String.trim(interest.message) %></div>
           </div>
         </div>
       </div>

--- a/lib/adoptoposs_web/templates/project/index.html.leex
+++ b/lib/adoptoposs_web/templates/project/index.html.leex
@@ -58,9 +58,7 @@
                 <b>I’m looking for…</b>
               </div>
 
-              <div class="markdown text-gray-700 my-2 md:mb-4">
-                <%= {:safe, Earmark.as_html!(project.description)} %>
-              </div>
+              <div class="whitespace-pre-wrap text-gray-700 my-2 md:mb-4"><%= project.description %></div>
 
               <div class="flex justify-between items-end">
                 <div class="mt-2 mb-4">

--- a/lib/adoptoposs_web/templates/project/show.html.leex
+++ b/lib/adoptoposs_web/templates/project/show.html.leex
@@ -35,9 +35,7 @@
             </div>
 
             <div class="flex flex-col md:pl-16 pl-0 pt-6 w-full">
-              <div>
-                <%= {:safe, Earmark.as_html!(String.trim(interest.message))} %>
-              </div>
+              <div class="whitespace-pre-wrap"><%= String.trim(interest.message) %></div>
 
               <div class="flex flex-row justify-between items-center">
                 <div class="text-gray-600 text-sm">


### PR DESCRIPTION
Just for security reasons. And because it's not needed to display a text
with line breaks.