### PR TITLE
Fix search with nil query

### DIFF
--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -79,8 +79,7 @@ config :new_relic_agent,
   app_name: System.get_env("NEW_RELIC_APP_NAME") || "Adoptoposs",
   license_key: System.get_env("NEW_RELIC_LICENSE_KEY")
 
-config :adoptoposs, AdoptopossWeb.Endpoint,
-  instrumenters: [NewRelic.Phoenix.Instrumenter]
+config :adoptoposs, AdoptopossWeb.Endpoint, instrumenters: [NewRelic.Phoenix.Instrumenter]
 
 # ## Using releases (Elixir v1.9+)
 #

--- a/lib/adoptoposs/search.ex
+++ b/lib/adoptoposs/search.ex
@@ -10,7 +10,7 @@ defmodule Adoptoposs.Search do
   alias Adoptoposs.Submissions.Project
   alias Adoptoposs.Tags.Tag
 
-  def find_projects(query, offset: offset, limit: limit) do
+  def find_projects(query, offset: offset, limit: limit) when is_binary(query) do
     terms = Regex.split(~r/[\s\.-_]/, String.downcase(query))
 
     Project
@@ -24,7 +24,9 @@ defmodule Adoptoposs.Search do
     |> Repo.all()
   end
 
-  def find_tags(query, offset: offset, limit: limit) do
+  def find_projects(_query, _opts), do: []
+
+  def find_tags(query, offset: offset, limit: limit) when is_binary(query) do
     terms = Regex.split(~r/[\s\.-_]/, String.downcase(query))
 
     Tag
@@ -35,6 +37,8 @@ defmodule Adoptoposs.Search do
     |> order_by(:name)
     |> Repo.all()
   end
+
+  def find_tags(_query, _opts), do: []
 
   defp where_all_terms_match(query, terms, fun) do
     Enum.reduce(terms, query, fun)

--- a/test/adoptoposs/search_test.exs
+++ b/test/adoptoposs/search_test.exs
@@ -37,6 +37,12 @@ defmodule Adoptoposs.SearchTest do
       assert [] == projects
     end
 
+    test "find_projects/2 with a not binary query returns empty list" do
+      assert [] == Search.find_projects(nil, offset: 0, limit: 1)
+      assert [] == Search.find_projects([], offset: 0, limit: 1)
+      assert [] == Search.find_projects(%{}, offset: 0, limit: 1)
+    end
+
     test "find_tags/2 returns the matching tags" do
       tag_1 = insert(:tag, name: "Java", type: Tag.Language.type())
       tag_2 = insert(:tag, name: "JavaScript", type: Tag.Language.type())
@@ -56,6 +62,12 @@ defmodule Adoptoposs.SearchTest do
 
       tags = Search.find_tags(query, offset: 2, limit: 1)
       assert [] == tags
+    end
+
+    test "find_tags/2 with a not binary query returns empty list" do
+      assert [] == Search.find_tags(nil, offset: 0, limit: 1)
+      assert [] == Search.find_tags([], offset: 0, limit: 1)
+      assert [] == Search.find_tags(%{}, offset: 0, limit: 1)
     end
   end
 end

--- a/test/adoptoposs_web/controllers/page_controller_test.exs
+++ b/test/adoptoposs_web/controllers/page_controller_test.exs
@@ -13,7 +13,8 @@ defmodule AdoptopossWeb.PageControllerTest do
 
   @tag login_as: "user123"
   test "page paths are visible for logged in users", %{conn: conn} do
-    [:faq, :privacy] |> Enum.each(fn action ->
+    [:faq, :privacy]
+    |> Enum.each(fn action ->
       conn = get(conn, Routes.page_path(conn, action))
       assert html_response(conn, 200)
     end)


### PR DESCRIPTION
Reported stacktrace

```
FunctionClauseError: (FunctionClauseError) no function clause matching in String.downcase/2

(elixir 1.10.1) lib/string.ex:785: String.downcase(nil, :default)(adoptoposs 0.1.0) lib/adoptoposs  
/search.ex:14: Adoptoposs.Search.find_projects/2(adoptoposs 0.1.0) lib/adoptoposs_web  
/live/search_live.ex:50: AdoptopossWeb.SearchLive.search/2(adoptoposs 0.1.0)   
lib/adoptoposs_web/live/search_live.ex:45:   
AdoptopossWeb.SearchLive.handle_event/3(phoenix_live_view 0.10.0) lib/phoenix_live_view  
/channel.ex:92: Phoenix.LiveView.Channel.handle_info/2(stdlib 3.11) gen_server.erl:637:   
:gen_server.try_dispatch/4(stdlib 3.11) gen_server.erl:711: :gen_server.handle_msg/6(stdlib 3.11)  
proc_lib.erl:249: :proc_lib.init_p_do_apply/3(phoenix_live_view 0.10.0)  Phoenix.LiveView.Channel.init(:Argument__1)
```