### PR TITLE
Adjust meta tags for shared project page

### DIFF
--- a/lib/adoptoposs_web/templates/shared/meta_tags.html.eex
+++ b/lib/adoptoposs_web/templates/shared/meta_tags.html.eex
@@ -1,7 +1,8 @@
-<% title = "Adoptoposs · Keep open source software maintained" %>
-<% description = "Adoptoposs helps maintainers of open source software to finding co-maintainers or people to take over their project." %>
-<% url = Plug.Conn.request_url(@conn) %>
-<% image = Routes.static_url(@conn, "/images/adoptoposs-social.jpg") %>
+<% title = AdoptopossWeb.SharingView.title(assigns) %>
+<% description = AdoptopossWeb.SharingView.description(assigns) %>
+<% image = AdoptopossWeb.SharingView.image(assigns) %>
+<% url = AdoptopossWeb.SharingView.url(assigns) %>
+<% twitter_card_type = AdoptopossWeb.SharingView.twitter_card_type(assigns) %>
 
 <title><%= title %></title>
 <meta content="<%= title %>" name="title">
@@ -13,10 +14,12 @@
 <meta content="<%= title %>" property="og:title">
 <meta content="<%= description %>" property="og:description">
 <meta content="<%= image %>" property="og:image">
+<meta content="Adoptoposs" property="og:site_name">
 
 <%# Twitter tags %>
-<meta content="summary_large_image" name="twitter:card">
+<meta content="<%= twitter_card_type %>" name="twitter:card">
 <meta content="<%= url %>" name="twitter:url">
 <meta content="<%= title %>" name="twitter:title">
 <meta content="<%= description %>" name="twitter:description">
 <meta content="<%= image %>" name="twitter:image">
+<meta content="@adoptoposs" name="twitter:site">

--- a/lib/adoptoposs_web/views/sharing_view.ex
+++ b/lib/adoptoposs_web/views/sharing_view.ex
@@ -1,3 +1,37 @@
 defmodule AdoptopossWeb.SharingView do
   use AdoptopossWeb, :view
+
+  alias Adoptoposs.Submissions.Project
+  alias Adoptoposs.Accounts.User
+
+  def title(%{project: project}) when not is_nil(project) do
+    "#{AdoptopossWeb.SharedView.project_name(project)} needs your help!"
+  end
+
+  def title(_assigns) do
+    "Adoptoposs · Keep open source software maintained"
+  end
+
+  def description(%{project: %Project{user: %User{username: username}} = project}) do
+    "@#{username} is looking for: #{String.trim(project.description)}"
+  end
+
+  def description(_assigns) do
+    "Adoptoposs helps maintainers of open source software to finding co-maintainers or people to take over their project."
+  end
+
+  def image(%{project: project}) when not is_nil(project) do
+    project.data["owner"]["avatar_url"]
+  end
+
+  def image(assigns) do
+    Routes.static_url(assigns.conn, "/images/adoptoposs-social.jpg")
+  end
+
+  def url(assigns) do
+    Plug.Conn.request_url(assigns.conn)
+  end
+
+  def twitter_card_type(%{project: _project}), do: "summary"
+  def twitter_card_type(_assigns), do: "summary_large_image"
 end


### PR DESCRIPTION
A subsequent sharing page fix to display proper project info via meta tags.