### PR TITLE
Add biweekly option and tests

### DIFF
--- a/lib/adoptoposs/accounts/settings.ex
+++ b/lib/adoptoposs/accounts/settings.ex
@@ -18,6 +18,7 @@ defmodule Adoptoposs.Accounts.Settings do
 
   @email_project_recommendations_values ~w(
     weekly
+    biweekly
     monthly
     off
   )

--- a/lib/adoptoposs/jobs/policy.ex
+++ b/lib/adoptoposs/jobs/policy.ex
@@ -14,6 +14,18 @@ defmodule Adoptoposs.Jobs.Policy do
     matches_weekday?(date, permitted_weekday)
   end
 
+  @doc """
+  Authorizes to send biweekly emails if the given date is on the `permitted_weekday`.
+  """
+  def authorize(:send_emails_biweekly, %Date{} = date, permitted_weekday) do
+    day = date.day
+
+    case matches_weekday?(date, permitted_weekday) do
+      true when day <= 7 or day in 14..20 -> true
+      _ -> false
+    end
+  end
+
   def authorize(_, _, _), do: :error
 
   defp matches_weekday?(date, weekday) when is_integer(weekday) do

--- a/lib/adoptoposs/jobs/policy.ex
+++ b/lib/adoptoposs/jobs/policy.ex
@@ -1,13 +1,14 @@
 defmodule Adoptoposs.Jobs.Policy do
   # first 7 days of the week
-  @first_week 7
+  @first_week 1..7
+  @third_week 15..21
 
   @doc """
   Authorizes to send monthly emails if the given date is the first
   `permitted_weekday` of the month.
   """
   def authorize(:send_emails_monthly, %Date{} = date, permitted_weekday) do
-    date.day <= @first_week && matches_weekday?(date, permitted_weekday)
+    date.day in @first_week && matches_weekday?(date, permitted_weekday)
   end
 
   @doc """
@@ -23,11 +24,7 @@ defmodule Adoptoposs.Jobs.Policy do
   def authorize(:send_emails_biweekly, %Date{} = date, permitted_weekday) do
     day = date.day
 
-    case matches_weekday?(date, permitted_weekday) do
-      true when day <= @first_week -> true
-      true when day in 14..20 -> true
-      _ -> false
-    end
+    (day in @first_week || day in @third_week) && matches_weekday?(date, permitted_weekday)
   end
 
   def authorize(_, _, _), do: :error

--- a/lib/adoptoposs/jobs/policy.ex
+++ b/lib/adoptoposs/jobs/policy.ex
@@ -1,10 +1,13 @@
 defmodule Adoptoposs.Jobs.Policy do
+  # first 7 days of the week
+  @first_week 7
+
   @doc """
   Authorizes to send monthly emails if the given date is the first
   `permitted_weekday` of the month.
   """
   def authorize(:send_emails_monthly, %Date{} = date, permitted_weekday) do
-    date.day <= 7 && matches_weekday?(date, permitted_weekday)
+    date.day <= @first_week && matches_weekday?(date, permitted_weekday)
   end
 
   @doc """
@@ -21,7 +24,8 @@ defmodule Adoptoposs.Jobs.Policy do
     day = date.day
 
     case matches_weekday?(date, permitted_weekday) do
-      true when day <= 7 or day in 14..20 -> true
+      true when day <= @first_week -> true
+      true when day in 14..20 -> true
       _ -> false
     end
   end

--- a/test/adoptoposs/accounts_test.exs
+++ b/test/adoptoposs/accounts_test.exs
@@ -12,7 +12,7 @@ defmodule Adoptoposs.AccountsTest do
     end
 
     test "email_project_recommendations/0 return all allowed values" do
-      assert Settings.email_project_recommendations_values() == ~w(weekly monthly off)
+      assert Settings.email_project_recommendations_values() == ~w(weekly biweekly monthly off)
     end
   end
 

--- a/test/adoptoposs/jobs_test.exs
+++ b/test/adoptoposs/jobs_test.exs
@@ -52,6 +52,36 @@ defmodule Adoptoposs.JobsTest do
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_weekly, date, 6)
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_weekly, date, 7)
     end
+
+    test "send_emails_biweekly is permitted for the first permitted weekday of the month", %{
+      date: date
+    } do
+      assert :ok = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
+      assert :ok = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+    end
+
+    test "send_emails_biweekly is permitted on the permitted weekday for the second half of the month" do
+      {:ok, date} = Date.new(2222, 01, 15)
+
+      assert :ok = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
+      assert :ok = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+    end
+
+    test "send_emails_biweekly is forbidden if the given date is not week 1 or week 3" do
+      # First authorized day within the first two weeks of the month
+      {:ok, date} = Date.new(2222, 01, 08)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+
+      # First authorized day within the first two weeks of the month
+      {:ok, date} = Date.new(2222, 01, 29)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+    end
   end
 
   describe "jobs" do
@@ -63,8 +93,12 @@ defmodule Adoptoposs.JobsTest do
 
     setup do
       weekly_users = insert_list(2, :user, settings: %{email_project_recommendations: "weekly"})
+
+      biweekly_users =
+        insert_list(2, :user, settings: %{email_project_recommendations: "biweekly"})
+
       monthly_users = insert_list(2, :user, settings: %{email_project_recommendations: "monthly"})
-      users = weekly_users ++ monthly_users
+      users = weekly_users ++ biweekly_users ++ monthly_users
 
       tag = insert(:tag, type: Tag.Language.type())
       insert(:project, language: tag)
@@ -73,22 +107,25 @@ defmodule Adoptoposs.JobsTest do
         insert(:tag_subscription, user: user, tag: tag)
       end
 
-      {:ok, %{weekly_users: weekly_users, monthly_user: monthly_users}}
+      {:ok,
+       %{weekly_users: weekly_users, biweekly_users: biweekly_users, monthly_user: monthly_users}}
     end
 
     test "send_project_recommendations/0 sends all weekly emails", %{
       weekly_users: weekly_users,
+      biweekly_users: biweekly_users,
       monthly_user: monthly_users
     } do
       expect(PolicyMock, :authorize, 3, fn action, _, _ ->
         case action do
           :send_emails_weekly -> :ok
+          :send_emails_biweekly -> :error
           :send_emails_monthly -> :error
           _ -> :error
         end
       end)
 
-      assert [ok: {"weekly", emails}, error: {"monthly", []}] =
+      assert [ok: {"weekly", emails}, error: {"biweekly", []}, error: {"monthly", []}] =
                Jobs.send_project_recommendations(PolicyMock)
 
       assert Enum.count(emails) == Enum.count(weekly_users)
@@ -97,6 +134,53 @@ defmodule Adoptoposs.JobsTest do
         email = emails |> Enum.at(index)
         assert %{subject: @recommendations_subject, to: [nil: ^receiver]} = email
         assert_delivered_email(email)
+      end
+
+      for user <- biweekly_users do
+        refute_email_delivered_with(
+          subject: @recommendations_subject,
+          to: [nil: user.email]
+        )
+      end
+
+      for user <- monthly_users do
+        refute_email_delivered_with(
+          subject: @recommendations_subject,
+          to: [nil: user.email]
+        )
+      end
+    end
+
+    test "send_project_recommendations/0 sends all biweekly emails", %{
+      weekly_users: weekly_users,
+      biweekly_users: biweekly_users,
+      monthly_user: monthly_users
+    } do
+      expect(PolicyMock, :authorize, 3, fn action, _, _ ->
+        case action do
+          :send_emails_weekly -> :error
+          :send_emails_biweekly -> :ok
+          :send_emails_monthly -> :error
+          _ -> :error
+        end
+      end)
+
+      assert [error: {"weekly", []}, ok: {"biweekly", emails}, error: {"monthly", []}] =
+               Jobs.send_project_recommendations(PolicyMock)
+
+      assert Enum.count(emails) == Enum.count(biweekly_users)
+
+      for {%{email: receiver}, index} <- Enum.with_index(biweekly_users) do
+        email = emails |> Enum.at(index)
+        assert %{subject: @recommendations_subject, to: [nil: ^receiver]} = email
+        assert_delivered_email(email)
+      end
+
+      for user <- weekly_users do
+        refute_email_delivered_with(
+          subject: @recommendations_subject,
+          to: [nil: user.email]
+        )
       end
 
       for user <- monthly_users do
@@ -109,17 +193,19 @@ defmodule Adoptoposs.JobsTest do
 
     test "send_project_recommendations/0 sends all monthly emails", %{
       weekly_users: weekly_users,
+      biweekly_users: biweekly_users,
       monthly_user: monthly_users
     } do
       expect(PolicyMock, :authorize, 3, fn action, _, _ ->
         case action do
           :send_emails_weekly -> :error
+          :send_emails_biweekly -> :error
           :send_emails_monthly -> :ok
           _ -> :error
         end
       end)
 
-      assert [error: {"weekly", []}, ok: {"monthly", emails}] =
+      assert [error: {"weekly", []}, error: {"biweekly", []}, ok: {"monthly", emails}] =
                Jobs.send_project_recommendations(PolicyMock)
 
       assert Enum.count(emails) == Enum.count(monthly_users)
@@ -131,6 +217,13 @@ defmodule Adoptoposs.JobsTest do
       end
 
       for user <- weekly_users do
+        refute_email_delivered_with(
+          subject: @recommendations_subject,
+          to: [nil: user.email]
+        )
+      end
+
+      for user <- biweekly_users do
         refute_email_delivered_with(
           subject: @recommendations_subject,
           to: [nil: user.email]

--- a/test/adoptoposs/jobs_test.exs
+++ b/test/adoptoposs/jobs_test.exs
@@ -67,20 +67,73 @@ defmodule Adoptoposs.JobsTest do
       assert :ok = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
     end
 
-    test "send_emails_biweekly is forbidden if the given date is not week 1 or week 3" do
-      # First authorized day within the first two weeks of the month
+    test "send_emails_biweekly is only allowed on permitted weekday in weeks 1 and 3" do
+      # Permitted weekday, first day of week 2
       {:ok, date} = Date.new(2222, 01, 08)
 
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
 
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
 
-      # First authorized day within the first two weeks of the month
+      # Permitted weekday, last day of week 2
+      {:ok, date} = Date.new(2222, 01, 14)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 1)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "1")
+
+      # Permitted weekday, first day of week 4
+      {:ok, date} = Date.new(2222, 01, 22)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+
+      # Permitted weekday, last day of week 4
+      {:ok, date} = Date.new(2222, 01, 28)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 1)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "1")
+
+      # Permitted weekday in week 5
       {:ok, date} = Date.new(2222, 01, 29)
 
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 2)
 
       assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, "2")
+    end
+
+    test "send_emails_biweekly is forbidden in a weeks 1 and 3 if given date is not permitted weekday",
+         %{date: date} do
+      # Week 1
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 1)
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 3)
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 4)
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 5)
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 6)
+      assert {:error, :unauthorized} = Bodyguard.permit(Jobs, :send_emails_biweekly, date, 7)
+
+      # Week 2
+      {:ok, week2_date} = Date.new(222, 01, 15)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 1)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 3)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 4)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 5)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 6)
+
+      assert {:error, :unauthorized} =
+               Bodyguard.permit(Jobs, :send_emails_biweekly, week2_date, 7)
     end
   end
 


### PR DESCRIPTION
This adds the biweekly option and makes sure that accounts cannot receive emails more than twice in any single month. Also added some tests to cover that.