### PR TITLE
Remove bg color and invisible rounded class from language tag

### DIFF
--- a/lib/adoptoposs_web/templates/shared/language_tag.html.eex
+++ b/lib/adoptoposs_web/templates/shared/language_tag.html.eex
@@ -1,4 +1,4 @@
-<div class="flex flex-row flex-no-wrap min-width-0 items-center bg-white font-semibold rounded cursor-default <%= assigns[:class] %>">
+<div class="flex flex-row flex-no-wrap min-width-0 items-center font-semibold cursor-default <%= assigns[:class] %>">
   <div class="w-3 h-3 rounded rounded-full bg-gray-500"
     style="background-color: <%= @color %>;">
   </div>


### PR DESCRIPTION
A small visual fix.
Removes the always white background color of language tags.

The tag background should be the same as the surrounding background, this was not the case e.g. for the submitted repo card (on `/settings/repos` page, probably hard to see, but the card background was light gray, the language tag background white):
![Unbenannt](https://user-images.githubusercontent.com/1781347/82154458-67971300-986e-11ea-9cef-a098d8fa5e70.png)
