### PR TITLE
Sort interest messages for a project

### DIFF
--- a/lib/adoptoposs/submissions.ex
+++ b/lib/adoptoposs/submissions.ex
@@ -10,6 +10,7 @@ defmodule Adoptoposs.Submissions do
   alias Adoptoposs.Accounts.User
   alias Adoptoposs.Tags.Tag
   alias Adoptoposs.Submissions.{Project, Policy}
+  alias Adoptoposs.Communication.Interest
 
   defdelegate authorize(action, user, params), to: Policy
 
@@ -110,8 +111,13 @@ defmodule Adoptoposs.Submissions do
   def get_user_project(%User{} = user, id) do
     user
     |> Ecto.assoc(:projects)
-    |> preload(:user)
-    |> preload(interests: [:creator])
+    |> preload(
+      interests:
+        ^from(i in Interest,
+          preload: [:creator],
+          order_by: [desc: i.inserted_at]
+        )
+    )
     |> Repo.get(id)
   end
 

--- a/lib/adoptoposs/submissions/policy.ex
+++ b/lib/adoptoposs/submissions/policy.ex
@@ -8,7 +8,7 @@ defmodule Adoptoposs.Submissions.Policy do
       when action in [:show_project, :update_project, :delete_project],
       do: :ok
 
-  def authorize(action, %User{}, %Project{})
+  def authorize(action, %User{}, _project)
       when action in [:show_project, :update_project, :delete_project],
       do: :error
 end

--- a/lib/adoptoposs_web/live/project_live/show.ex
+++ b/lib/adoptoposs_web/live/project_live/show.ex
@@ -10,7 +10,7 @@ defmodule AdoptopossWeb.ProjectLive.Show do
 
   def mount(%{"id" => id}, %{"user_id" => user_id}, socket) do
     user = Accounts.get_user!(user_id)
-    project = Submissions.get_project!(id, preload: [interests: [:creator, project: [:user]]])
+    project = Submissions.get_user_project(user, id)
 
     with :ok <- Bodyguard.permit(Submissions, :show_project, user, project) do
       {:ok, assign(socket, user_id: user_id, project: project)}

--- a/test/adoptoposs/submissions_test.exs
+++ b/test/adoptoposs/submissions_test.exs
@@ -49,6 +49,14 @@ defmodule Adoptoposs.SubmissionsTest do
 
       assert {:error, :unauthorized} = Bodyguard.permit(Submissions, :show_project, user, project)
     end
+
+    test "project actions are forbidden for a nil project" do
+      user = build(:user, id: 1)
+
+      assert {:error, :unauthorized} = Bodyguard.permit(Submissions, :show_project, user, nil)
+      assert {:error, :unauthorized} = Bodyguard.permit(Submissions, :update_project, user, nil)
+      assert {:error, :unauthorized} = Bodyguard.permit(Submissions, :delete_project, user, nil)
+    end
   end
 
   describe "project" do


### PR DESCRIPTION
Changes the displaying order of interest messages for a project. (`/projects/<id>/messages`)
More recent messages are now displayed first.

Because it uses `Submissions.get_user_project/2` now, the returned project might be nil. That’s why the policy also needs to handle this. In theory, we could just check for a `nil` project instead of using the policy, but I guess it might make sense to keep using it here as well, just to have the permissions handling in one place and consistently applied.