### PR TITLE
Use default max_concurrency & :kill_task on email timeout

### DIFF
--- a/lib/adoptoposs/jobs/project_recommendations.ex
+++ b/lib/adoptoposs/jobs/project_recommendations.ex
@@ -10,14 +10,13 @@ defmodule Adoptoposs.Jobs.ProjectRecommendations do
   alias AdoptopossWeb.Mailer
 
   @project_per_tag 3
-  @task_max_concurrency 25
   @task_timeout 30_000
 
   @doc """
   Sends emails with recommended projects to all users with enabled setting.
   """
   def send_emails(setting) do
-    opts = [max_concurrency: @task_max_concurrency, timeout: @task_timeout]
+    opts = [timeout: @task_timeout, on_timeout: :kill_task]
 
     setting
     |> get_user_ids()


### PR DESCRIPTION
Fixes issues with emailing project recommendations.

Email delivery should not stop for all emails if one delivery task timed out. Instead, now only the timed out task is killed.

See https://hexdocs.pm/elixir/Task.html#async_stream/5-options for an explanation of the used options.