### PR TITLE
Restrict access for shared projects to published projects only

### DIFF
--- a/lib/adoptoposs/submissions.ex
+++ b/lib/adoptoposs/submissions.ex
@@ -75,16 +75,17 @@ defmodule Adoptoposs.Submissions do
 
   ## Examples
 
-      iex> get_project_by_uuid(user, "61900487-e6e3-4a3b-881f-e3fe5e2ca5f1")
+      iex> get_published_project_by_uuid(user, "61900487-e6e3-4a3b-881f-e3fe5e2ca5f1")
       %Project{}
 
-      iex> get_project_by_uuid(user, "no-existing")
+      iex> get_published_project_by_uuid(user, "not-existing")
       nil
 
   """
-  def get_project_by_uuid(uuid, opts \\ []) do
+  def get_published_project_by_uuid(uuid, opts \\ []) do
     with {:ok, value} <- Ecto.UUID.cast(uuid) do
-      from(p in Project, preload: ^(opts[:preload] || []), where: ^(opts[:where] || []))
+      from(p in Project, preload: ^(opts[:preload] || []))
+      |> where(status: ^:published)
       |> where(uuid: ^value)
       |> Repo.one()
     else

--- a/lib/adoptoposs/submissions.ex
+++ b/lib/adoptoposs/submissions.ex
@@ -84,10 +84,8 @@ defmodule Adoptoposs.Submissions do
   """
   def get_project_by_uuid(uuid, opts \\ []) do
     with {:ok, value} <- Ecto.UUID.cast(uuid) do
-      from(p in Project,
-        where: p.uuid == ^value,
-        preload: ^(opts[:preload] || [])
-      )
+      from(p in Project, preload: ^(opts[:preload] || []), where: ^(opts[:where] || []))
+      |> where(uuid: ^value)
       |> Repo.one()
     else
       :error ->

--- a/lib/adoptoposs_web/live/sharing_live.ex
+++ b/lib/adoptoposs_web/live/sharing_live.ex
@@ -16,12 +16,8 @@ defmodule AdoptopossWeb.SharingLive do
   end
 
   defp assign_project(socket, uuid) do
-    options = [
-      where: [status: :published],
-      preload: [:user, :language, interests: [:creator]]
-    ]
-
-    project = Submissions.get_project_by_uuid(uuid, options)
+    options = [preload: [:user, :language, interests: [:creator]]]
+    project = Submissions.get_published_project_by_uuid(uuid, options)
     assign(socket, project: project)
   end
 end

--- a/lib/adoptoposs_web/live/sharing_live.ex
+++ b/lib/adoptoposs_web/live/sharing_live.ex
@@ -16,7 +16,11 @@ defmodule AdoptopossWeb.SharingLive do
   end
 
   defp assign_project(socket, uuid) do
-    options = [preload: [:user, :language, interests: [:creator]]]
+    options = [
+      where: [status: :published],
+      preload: [:user, :language, interests: [:creator]]
+    ]
+
     project = Submissions.get_project_by_uuid(uuid, options)
     assign(socket, project: project)
   end

--- a/test/adoptoposs/submissions_test.exs
+++ b/test/adoptoposs/submissions_test.exs
@@ -104,23 +104,25 @@ defmodule Adoptoposs.SubmissionsTest do
       end
     end
 
-    test "get_project_by_uuid/1 returns the project with the given uuid" do
+    test "get_published_project_by_uuid/2 returns the project with the given uuid" do
       project = insert(:project)
-      assert Submissions.get_project_by_uuid(project.uuid).id == project.id
+      assert Submissions.get_published_project_by_uuid(project.uuid).id == project.id
     end
 
-    test "get_project_by_uuid/1 allows passing query options" do
+    test "get_published_project_by_uuid/2 returns only published projects" do
       draft_project = insert(:project, status: :draft)
-      opts = [where: [status: :published]]
-      refute Submissions.get_project_by_uuid(draft_project.uuid, opts)
+      refute Submissions.get_published_project_by_uuid(draft_project.uuid)
+    end
 
+    test "get_published_project_by_uuid/2 allows passing preload options" do
+      %Project{uuid: uuid} = insert(:project)
       opts = [preload: :interests]
-      project = Submissions.get_project_by_uuid(draft_project.uuid, opts)
+      project = Submissions.get_published_project_by_uuid(uuid, opts)
       assert project.interests == []
     end
 
-    test "get_project_by_uuid/1 returns nil when the project does not exist" do
-      assert is_nil(Submissions.get_project_by_uuid("no-exiting"))
+    test "get_published_project_by_uuid/2 returns nil when the project does not exist" do
+      assert is_nil(Submissions.get_published_project_by_uuid("no-exiting"))
     end
 
     test "get_user_project/2 returns the project with given id" do

--- a/test/adoptoposs/submissions_test.exs
+++ b/test/adoptoposs/submissions_test.exs
@@ -109,6 +109,16 @@ defmodule Adoptoposs.SubmissionsTest do
       assert Submissions.get_project_by_uuid(project.uuid).id == project.id
     end
 
+    test "get_project_by_uuid/1 allows passing query options" do
+      draft_project = insert(:project, status: :draft)
+      opts = [where: [status: :published]]
+      refute Submissions.get_project_by_uuid(draft_project.uuid, opts)
+
+      opts = [preload: :interests]
+      project = Submissions.get_project_by_uuid(draft_project.uuid, opts)
+      assert project.interests == []
+    end
+
     test "get_project_by_uuid/1 returns nil when the project does not exist" do
       assert is_nil(Submissions.get_project_by_uuid("no-exiting"))
     end

--- a/test/adoptoposs_web/live/sharing_live_test.exs
+++ b/test/adoptoposs_web/live/sharing_live_test.exs
@@ -18,8 +18,14 @@ defmodule AdoptopossWeb.SharingLiveTest do
     assert html_response(conn, 200) =~ "#{project.repo_owner}/#{project.name}"
   end
 
-  test "disconnected mount with invalid uuid", %{conn: conn} do
+  test "disconnected mount of /projects/:uuid with invalid uuid", %{conn: conn} do
     conn = get(conn, Routes.live_path(conn, SharingLive, "invalid-uuid"))
+    assert html_response(conn, 200) =~ "The project is not available"
+  end
+
+  test "disconnected mount of /projects/:uuid with not published project", %{conn: conn} do
+    project = insert(:project, status: :draft)
+    conn = get(conn, Routes.live_path(conn, SharingLive, project.uuid))
     assert html_response(conn, 200) =~ "The project is not available"
   end
 
@@ -34,5 +40,16 @@ defmodule AdoptopossWeb.SharingLiveTest do
     project = insert(:project)
     {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, project.uuid))
     assert html =~ "#{project.repo_owner}/#{project.name}"
+  end
+
+  test "connected mount of /projects/:uuid with invalid uuid", %{conn: conn} do
+    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, "invalid-uuid"))
+    assert html =~ "The project is not available"
+  end
+
+  test "connected mount of /projects/:uuid for not published project", %{conn: conn} do
+    project = insert(:project, status: :draft)
+    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    assert html =~ "The project is not available"
   end
 end


### PR DESCRIPTION
Follow up fix for #72 to prevent access to unpublished shared projects.