### PR TITLE
Chore: Add caching to elixir workflow + utility make commands

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
 [
   import_deps: [:ecto, :phoenix],
-  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  inputs: ["*.{ex,exs}", "priv/*/seeds.exs", "{config,lib,test}/**/*.{ex,exs,exs.sample}"],
   subdirectories: ["priv/*/migrations"]
 ]

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,13 +8,43 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup test environment
-      run: make setup-test
+
+    - name: Cache hex deps
+      id: mix-cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          deps
+          _build
+          !_build/*/lib/adoptoposs
+        key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+
+    - name: Cache yarn
+      id: yarn-cache
+      uses: actions/cache@v2
+      with:
+        path: "**/node_modules"
+        key: ${{ runner.os }}-yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/**/yarn.lock')) }}
+
+    - name: Setup environment
+      run: |
+        make dev-config
+        make build
+
+    - name: Install hex dependencies
+      if: steps.mix-cache.outputs.cache-hit != 'true'
+      run: make hex-deps
+
+    - name: Install yarn
+      if: steps.yarn-cache.outputs.cache-hit != 'true'
+      run: make yarn
+
     - name: Run tests
       run: make test
 
+    - name: Check code formatting
+      run: make check-formatted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,25 @@ Here’s how to contribute:
 * Push to the branch (git push origin feature/my-new-feature)
 * Create a new Pull Request
 
-Try to add tests along with your new feature. This will ensure that your code does not break existing functionality and that your feature is working as expected.
+Try to add tests along with your new feature. This will ensure that your code does not break existing functionality and that your feature is working as expected. You can run the tests with:
 
-If you’ve changed any Elixir code, please run Elixir’s code formatter before committing your changes. This will keep the code style consistent and future code diffs as small as possible.
+```bash
+make test
+```
+
+To watch file changes and rerun the test suite automatically, you can use:
+
+```bash
+make test-watch
+```
+
+If you’ve changed any Elixir code, please run Elixir’s code formatter before committing your changes:
+
+```bash
+make format
+```
+
+This will keep the code style consistent and future code diffs as small as possible.
 
 ---------
 

--- a/config/dev.exs.sample
+++ b/config/dev.exs.sample
@@ -102,5 +102,4 @@ config :adoptoposs, :basic_auth,
   password: System.get_env("BASIC_AUTH_PASSWORD")
 
 # Mailing
-config :adoptoposs, AdoptopossWeb.Mailer,
-  adapter: Bamboo.LocalAdapter
+config :adoptoposs, AdoptopossWeb.Mailer, adapter: Bamboo.LocalAdapter

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ setup: dev-config build hex-deps yarn db-setup db-setup-test
 setup-test: dev-config build hex-deps yarn db-setup-test
 
 dev-config:
-	cp -u config/dev.exs.sample config/dev.exs
+	rsync --ignore-existing config/dev.exs.sample config/dev.exs
 build:
 	$(call dc, build)
 hex-deps:

--- a/makefile
+++ b/makefile
@@ -13,9 +13,12 @@ usage:
 	@echo "  * yarn             - Install missing node dependencies"
 	@echo "  * db-setup         - Create & migrate the development database"
 	@echo "  * db-migrate       - Migrate the development database"
+	@echo "  * setup-test       - Initiate everything needed for running the tests, e.g. in CI"
 	@echo "  * db-setup-test    - Create & migrate the test database"
 	@echo "  * shell            - Fire up a shell inside of your container"
 	@echo "  * iex              - Fire up a iex console inside of your container"
+	@echo "  * format           - Run the Elixir code formatter"
+	@echo "  * check-formatted  - Check whether all Elixir code is formatted"
 	@echo "  * up               - Run the development server"
 	@echo "  * down             - Remove containers and tear down the setup"
 	@echo "  * stop             - Stop the development server"
@@ -46,6 +49,10 @@ shell:
 	$(call dc-run, ash)
 iex:
 	$(call dc-run, iex -S mix)
+format:
+	$(call dc-run, mix format)
+check-formatted:
+	$(call dc-run, mix format --check-formatted)
 up:
 	$(call dc, up)
 down:
@@ -56,4 +63,3 @@ test:
 	$(call dc-run, mix test)
 test-watch:
 	$(call dc-run, mix test.watch)
-


### PR DESCRIPTION
Some enhancements to speed up the development process:

* Adds some caching to the CI workflow
* Adds an Elixir code formatting check to the CI run
* Adds `make format` & `make check-formatted` commands
* Adds some hints for formatting & testing to the CONTRIBUTING guide
* Fix dev setup on Mac (missing cp -u option in `make dev-config`)