### PR TITLE
Make repo description searchable

### DIFF
--- a/lib/adoptoposs/network.ex
+++ b/lib/adoptoposs/network.ex
@@ -18,6 +18,13 @@ defmodule Adoptoposs.Network do
   end
 
   @doc """
+  Fetch repositories with the given ids from the given provider.
+  """
+  def repos(token, provider, ids) do
+    api(provider).repos(token, ids)
+  end
+
+  @doc """
   Fetch a user's public repositories from the given provider.
   """
   def user_repos(token, provider, limit, after_cursor \\ "")

--- a/lib/adoptoposs/network/api.ex
+++ b/lib/adoptoposs/network/api.ex
@@ -2,12 +2,23 @@ defprotocol Adoptoposs.Network.Api do
   alias Adoptoposs.Network.{Repository, Organization, PageInfo}
 
   @doc """
+  Get the provider for the Api.
+  """
+  @callback provider() :: String.t()
+
+  @doc """
   Get the current user’s paginated administerable organizations.
   It takes the auth token, the limit and a start cursor for pagination.
   It returns a result tuple containing the `PageInfo` and a list of `Organization`s.
   """
   @callback organizations(String.t(), integer(), String.t()) ::
               {atom(), {PageInfo.t(), list(Organization.t())}}
+
+  @doc """
+  Get repos for given ids.
+  It returns a result tuple containing a list of `Repository`s.
+  """
+  @callback repos(String.t(), list(String.t())) :: {atom(), list(Repository.t())}
 
   @doc """
   Get paginated repos for a given organisation.

--- a/lib/adoptoposs/search.ex
+++ b/lib/adoptoposs/search.ex
@@ -71,6 +71,7 @@ defmodule Adoptoposs.Search do
       where:
         ilike(project.name, ^"%#{term}%") or
           ilike(project.repo_owner, ^"%#{term}%") or
+          ilike(project.repo_description, ^"%#{term}%") or
           ilike(project.description, ^"%#{term}%")
   end
 

--- a/lib/adoptoposs/submissions.ex
+++ b/lib/adoptoposs/submissions.ex
@@ -190,13 +190,31 @@ defmodule Adoptoposs.Submissions do
       iex> update_project_status(project, :published)
       {:ok, %Project{}}
 
-      iex> update_project(project, :not_allowed_status)
+      iex> update_project_status(project, :not_allowed_status)
       {:error, %Ecto.Changeset{}}
 
   """
   def update_project_status(%Project{} = project, status) do
     project
     |> Project.status_changeset(%{status: status})
+    |> Repo.update()
+  end
+
+  @doc """
+  Updates the repo data of a project.
+
+  ## Examples
+
+      iex> update_project_data(project, repository)
+      {:ok, %Project{}}
+
+      iex> update_project_data(project, repository_with_missing_data)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_project_data(%Project{} = project, %Repository{} = repository, attrs \\ %{}) do
+    project
+    |> Project.update_data_changeset(repository, attrs)
     |> Repo.update()
   end
 

--- a/lib/adoptoposs_web/templates/shared/project_repo.html.eex
+++ b/lib/adoptoposs_web/templates/shared/project_repo.html.eex
@@ -7,7 +7,7 @@
   </h2>
 
   <div class="markdown text-gray-600">
-    <%= {:safe, Earmark.as_html!(String.trim(project_description(@project)))} %>
+    <%= {:safe, Earmark.as_html!(project_description(@project))} %>
   </div>
 
   <div class="flex flex-row justify-between items-center mt-2 md:mt-4">

--- a/lib/adoptoposs_web/views/shared_view.ex
+++ b/lib/adoptoposs_web/views/shared_view.ex
@@ -15,8 +15,8 @@ defmodule AdoptopossWeb.SharedView do
   def project_url(%Project{} = project), do: project.data["url"]
   def project_url(%Repository{} = project), do: project.url
 
-  def project_description(%Project{} = project), do: project.data["description"]
-  def project_description(%Repository{} = project), do: project.description
+  def project_description(%Project{} = project), do: String.trim(project.repo_description)
+  def project_description(%Repository{} = project), do: String.trim(project.description)
 
   def count(word, count: count) when count < 1, do: "no #{word}s"
   def count(word, count: count) when count == 1, do: "#{count} #{word}"

--- a/mix.exs
+++ b/mix.exs
@@ -76,6 +76,7 @@ defmodule Adoptoposs.MixProject do
   defp aliases do
     [
       "fetch.languages": ["run priv/repo/fetch_languages.exs"],
+      "update.github_repos": ["run priv/repo/update_repo_data.exs --provider github"],
       "ecto.setup": ["ecto.create", "ecto.migrate", "fetch.languages", "run priv/repo/seeds.exs"],
       "ecto.reset": ["ecto.drop", "ecto.setup"],
       test: ["ecto.create --quiet", "ecto.migrate", "test"]

--- a/priv/repo/migrations/20200707155347_add_repo_description_to_projects.exs
+++ b/priv/repo/migrations/20200707155347_add_repo_description_to_projects.exs
@@ -1,0 +1,32 @@
+defmodule Adoptoposs.Repo.Migrations.AddRepoDescriptionToProjects do
+  use Ecto.Migration
+
+  alias Adoptoposs.Repo
+  import Ecto.Query, only: [from: 2]
+
+  def up do
+    alter table(:projects) do
+      add :repo_description, :string
+    end
+
+    # ensure the new column is added
+    flush()
+
+    # Copy over the repo description values
+    from(
+      p in "projects",
+      update: [set: [repo_description: p.data["description"]]]
+    )
+    |> Repo.update_all([])
+
+    execute "CREATE INDEX project_repo_description_trgm_index ON projects USING gin (repo_description gin_trgm_ops)"
+  end
+
+  def down do
+    execute "DROP INDEX project_repo_description_trgm_index"
+
+    alter table(:projects) do
+      remove :repo_description
+    end
+  end
+end

--- a/priv/repo/update_repo_data.exs
+++ b/priv/repo/update_repo_data.exs
@@ -1,0 +1,75 @@
+defmodule Adoptoposs.UpdateReposityData do
+  @moduledoc """
+  Update project repo data by fetching the repository data for each Project
+  from the respective provider.
+  """
+
+  import Ecto.Query, only: [from: 2]
+  alias Adoptoposs.{Repo, Submissions, Submissions.Project, Network, Tags}
+
+  @batch_size 100
+
+  @doc """
+  Run project update from provider repos.
+
+  Fetching the data from the provider API is done in batches of `@batch_size`,
+  because e.g. GitHub allows only batches of maximum 100 ids.
+  """
+  def run(provider: provider, token: token) do
+    Repo
+    |> stream(from(p in Project, select: [p.id, p.repo_id], order_by: p.updated_at))
+    |> Enum.each(& run_batch(&1, provider: provider, token: token))
+  end
+
+  defp run_batch(project_data, provider: provider, token: token) do
+    project_ids = project_data |> Enum.map(&List.first(&1))
+    repo_ids = project_data |> Enum.map(&List.last(&1))
+
+    with {:ok, repositories} <- Network.repos(token, provider, repo_ids) do
+      project_ids
+      |> Enum.with_index()
+      |> Enum.map(fn {id, index} -> update_data(id, repositories |> Enum.at(index)) end)
+    else
+      {:error, error} ->
+        IO.inspect(error)
+    end
+  end
+
+  defp update_data(project_id, %Network.Repository{} = repository) do
+    project = Submissions.get_project!(project_id)
+
+    if project.repo_id == repository.id do
+      %{id: language_id} = Tags.get_tag_by_name!(repository.language.name)
+      Submissions.update_project_data(project, repository, %{language_id: language_id})
+
+      # setting 1 second timeout in order to keep the updated_at order of projects
+      :timer.sleep(1000)
+    end
+  end
+
+  defp update_data(_project_id, _repository), do: nil
+
+  defp stream(repo, query, batch_size \\ @batch_size) do
+    Stream.unfold(0, fn
+      :done ->
+        nil
+
+      offset ->
+        results = repo.all(from _ in query, offset: ^offset, limit: ^batch_size)
+        state = if length(results) < batch_size, do: :done, else: offset + batch_size
+        { results, state }
+    end)
+  end
+end
+
+# Takes provider and API token as command line arguments,
+# so that it can be run as:
+#
+#    $ mix run run priv/repo/update_repo_data.exs github <api-token>
+#
+# or with the mix alias:
+#
+#    $ mix update.github_repos <api-token>
+#
+{[provider: provider, token: token], [], []} = OptionParser.parse(System.argv(), strict: [provider: :string, token: :string])
+Adoptoposs.UpdateReposityData.run(provider: provider, token: token)

--- a/test/adoptoposs/search_test.exs
+++ b/test/adoptoposs/search_test.exs
@@ -14,30 +14,35 @@ defmodule Adoptoposs.SearchTest do
       project_1 = insert(:project, name: "Pixi")
       project_2 = insert(:project, repo_owner: "FIXIT")
       project_3 = insert(:project, description: "FixIt")
+      project_4 = insert(:project, repo_description: "Fixit")
 
       insert(:project, language: build(:tag, name: "Ruby"))
       insert(:project, language: build(:tag, name: "JavaScript"))
 
       query = "IXi"
 
-      %{results: projects, total_count: 3} = Search.find_projects(query, offset: 0, limit: 3)
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 0, limit: 4)
 
       for project <- projects do
         assert %Tag{} = project.language
       end
 
-      assert [project_1.id, project_2.id, project_3.id] == projects |> Enum.map(& &1.id)
+      assert [project_1.id, project_2.id, project_3.id, project_4.id] ==
+               projects |> Enum.map(& &1.id)
 
-      %{results: projects, total_count: 3} = Search.find_projects(query, offset: 0, limit: 1)
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 0, limit: 1)
       assert [project_1.id] == projects |> Enum.map(& &1.id)
 
-      %{results: projects, total_count: 3} = Search.find_projects(query, offset: 1, limit: 1)
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 1, limit: 1)
       assert [project_2.id] == projects |> Enum.map(& &1.id)
 
-      %{results: projects, total_count: 3} = Search.find_projects(query, offset: 2, limit: 1)
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 2, limit: 1)
       assert [project_3.id] == projects |> Enum.map(& &1.id)
 
-      %{results: projects, total_count: 3} = Search.find_projects(query, offset: 3, limit: 1)
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 3, limit: 1)
+      assert [project_4.id] == projects |> Enum.map(& &1.id)
+
+      %{results: projects, total_count: 4} = Search.find_projects(query, offset: 4, limit: 1)
       assert [] == projects
     end
 

--- a/test/adoptoposs/submissions_test.exs
+++ b/test/adoptoposs/submissions_test.exs
@@ -233,6 +233,29 @@ defmodule Adoptoposs.SubmissionsTest do
       assert {:error, _} = Submissions.update_project_status(project, :some_invalid_status)
     end
 
+    test "update_project_data/3 updates the project’s repo data" do
+      project = insert(:project)
+      repository = build(:repository)
+      language = insert(:tag)
+      attrs = %{language_id: language.id}
+
+      assert {:ok, %Project{} = updated_project} =
+               Submissions.update_project_data(project, repository, attrs)
+
+      assert updated_project.name == repository.name
+      assert updated_project.repo_id == repository.id
+      assert updated_project.repo_description == repository.description
+      assert updated_project.language_id == language.id
+      assert updated_project.data == repository |> Map.from_struct()
+    end
+
+    test "update_project_data/3 fails for invalid repo data" do
+      project = insert(:project)
+      repository = build(:repository)
+      attrs = %{language_id: nil}
+      assert {:error, _} = Submissions.update_project_data(project, repository, attrs)
+    end
+
     test "delete_project/1 deletes the passed project" do
       project = insert(:project)
       assert {:ok, %Project{}} = Submissions.delete_project(project)

--- a/test/adoptoposs_web/views/shared_view_test.exs
+++ b/test/adoptoposs_web/views/shared_view_test.exs
@@ -37,6 +37,20 @@ defmodule AdoptopossWeb.SharedViewTest do
     end
   end
 
+  describe "project_description/1" do
+    test "returns the project description when passing a Project" do
+      description = "some project description"
+      project = build(:project, repo_description: description)
+      assert SharedView.project_description(project) == description
+    end
+
+    test "returns the repository description when passing a Repository" do
+      description = "some repository description"
+      repository = build(:repository, description: description)
+      assert SharedView.project_description(repository) == description
+    end
+  end
+
   describe "count/2" do
     test "returns number with passed word if number == 1" do
       assert SharedView.count("thing", count: 1) == "1 thing"

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -23,17 +23,19 @@ defmodule Adoptoposs.Factory do
   def project_factory do
     repo_id = sequence("repo_id")
     owner = build(:contributor, login: sequence("owner"))
+    repo = build(:repository, id: repo_id, owner: owner)
     uuid = Ecto.UUID.generate()
 
     %Submissions.Project{
       name: sequence("project"),
       language: build(:tag),
       # encode and decode repository to get the data as it is stored in the database
-      data: build(:repository, id: repo_id, owner: owner) |> Jason.encode!() |> Jason.decode!(),
+      data: repo |> Jason.encode!() |> Jason.decode!(),
       user: build(:user),
       description: "another co-maintainer",
       repo_id: repo_id,
       repo_owner: owner.login,
+      repo_description: repo.description,
       uuid: uuid,
       status: :published
     }
@@ -95,7 +97,7 @@ defmodule Adoptoposs.Factory do
     %Network.Repository{
       id: sequence("id"),
       name: sequence("Repo"),
-      description: "<div>Solving <i>all</i> the issues</div>",
+      description: "Solving all the issues",
       url: sequence(:url, &"https://example.com/repos/repo#{&1}"),
       owner: build(:contributor),
       language: build(:language),

--- a/test/support/network/api/github_in_memory.ex
+++ b/test/support/network/api/github_in_memory.ex
@@ -6,8 +6,16 @@ defmodule Adoptoposs.Network.Api.GithubInMemory do
   @behaviour Api
 
   @impl Api
+  def provider, do: Api.Github.provider()
+
+  @impl Api
   def organizations(_token, limit, _after_cursor) do
     {:ok, {build(:page_info), build_list(limit, :organization)}}
+  end
+
+  @impl Api
+  def repos(_token, ids) do
+    {:ok, ids |> Enum.map(&build(:repository, id: to_string(&1)))}
   end
 
   @impl Api


### PR DESCRIPTION
Fixes #82 

* Adds trigram index for project repo’s description to make it searchable
* Adds a routine for updating all repo data (needed because we migrate from descriptionHTML to plain description text)