### PR TITLE
Issue #98 - Share dialog not displaying correctly in Chrome

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -392,5 +392,8 @@ details.toggle {
         content: " ";
       }
     }
+    .toggle-content {
+      z-index: 1;
+    }
   }
 }


### PR DESCRIPTION
Fixes #
Issue #98 

## Proposed Changes

Adding `z-index: 1;` property to `toggle-content` class makes the dialog display correctly in Chrome.
  