### PR TITLE
Handle blank GitHub repo description

### DIFF
--- a/lib/adoptoposs_web/views/shared_view.ex
+++ b/lib/adoptoposs_web/views/shared_view.ex
@@ -15,8 +15,8 @@ defmodule AdoptopossWeb.SharedView do
   def project_url(%Project{} = project), do: project.data["url"]
   def project_url(%Repository{} = project), do: project.url
 
-  def project_description(%Project{} = project), do: String.trim(project.repo_description)
-  def project_description(%Repository{} = project), do: String.trim(project.description)
+  def project_description(%Project{} = project), do: String.trim(project.repo_description || "")
+  def project_description(%Repository{} = project), do: String.trim(project.description || "")
 
   def count(word, count: count) when count < 1, do: "no #{word}s"
   def count(word, count: count) when count == 1, do: "#{count} #{word}"

--- a/test/adoptoposs_web/views/shared_view_test.exs
+++ b/test/adoptoposs_web/views/shared_view_test.exs
@@ -49,6 +49,16 @@ defmodule AdoptopossWeb.SharedViewTest do
       repository = build(:repository, description: description)
       assert SharedView.project_description(repository) == description
     end
+
+    test "returns an empty string when passing a Project without repo_description" do
+      project = build(:project, repo_description: nil)
+      assert SharedView.project_description(project) == ""
+    end
+
+    test "returns an empty string when passing a Repository without description" do
+      repository = build(:repository, description: nil)
+      assert SharedView.project_description(repository) == ""
+    end
   end
 
   describe "count/2" do


### PR DESCRIPTION
This led to a bug were the submit repo page shows a 500 Error because of the template failed to render.