### PR TITLE
Enable gzip & brotli compression for static content

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,7 +18,7 @@ host =
     "#{System.get_env("HEROKU_APP_NAME")}.herokuapp.com"
 
 config :adoptoposs, AdoptopossWeb.Endpoint,
-  http: [port: {:system, "PORT"}],
+  http: [port: {:system, "PORT"}, compress: true],
   url: [scheme: "https", host: host, port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto]],
   cache_static_manifest: "priv/static/cache_manifest.json"

--- a/lib/adoptoposs_web/endpoint.ex
+++ b/lib/adoptoposs_web/endpoint.ex
@@ -27,7 +27,8 @@ defmodule AdoptopossWeb.Endpoint do
   plug Plug.Static,
     at: "/",
     from: :adoptoposs,
-    gzip: false,
+    gzip: true,
+    brotli: true,
     only: ~w(css fonts images js favicon.ico robots.txt)
 
   # Code reloading can be explicitly enabled under the

--- a/lib/adoptoposs_web/endpoint.ex
+++ b/lib/adoptoposs_web/endpoint.ex
@@ -13,7 +13,8 @@ defmodule AdoptopossWeb.Endpoint do
 
   socket "/live", Phoenix.LiveView.Socket,
     websocket: [
-      connect_info: [session: @session_options]
+      connect_info: [session: @session_options],
+      compress: true
     ]
 
   socket "/socket", AdoptopossWeb.UserSocket,


### PR DESCRIPTION
In order to reduce required bandwidth and speed up page loading.