### PR TITLE
Fix deprecation warning for new_relic_phoenix

### DIFF
--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -86,8 +86,6 @@ config :new_relic_agent,
   app_name: System.get_env("NEW_RELIC_APP_NAME") || "Adoptoposs",
   license_key: System.get_env("NEW_RELIC_LICENSE_KEY")
 
-config :adoptoposs, AdoptopossWeb.Endpoint, instrumenters: [NewRelic.Phoenix.Instrumenter]
-
 # ## Using releases (Elixir v1.9+)
 #
 # If you are doing OTP releases, you need to instruct Phoenix

--- a/lib/adoptoposs_web/endpoint.ex
+++ b/lib/adoptoposs_web/endpoint.ex
@@ -1,6 +1,5 @@
 defmodule AdoptopossWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :adoptoposs
-  use NewRelic.Phoenix.Transaction
 
   # The session will be stored in the cookie and signed,
   # this means its contents can be read but not tampered with.

--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Adoptoposs.MixProject do
       {:mjml, "~> 0.3.0"},
       {:navigation_history, "~> 0.4"},
       {:quantum, "~> 3.0"},
-      {:new_relic_phoenix, "~> 0.4"},
+      {:new_relic_agent, "~> 1.0"},
       {:ecto_enum, "~> 1.4"},
       {:mix_test_watch, "~> 1.0", only: :dev, runtime: false},
       {:faker, "~> 0.16", only: [:dev, :test]},


### PR DESCRIPTION
Fixes a deprecation warning from the new_relix_phoenix package. 
Uses new_relic_agent instead, see: https://github.com/newrelic/elixir_agent/pull/284 and the project's readme.