### PR TITLE
Use username for blank names when building user data from auth

### DIFF
--- a/lib/adoptoposs/accounts/user_from_auth.ex
+++ b/lib/adoptoposs/accounts/user_from_auth.ex
@@ -16,10 +16,14 @@ defmodule Adoptoposs.Accounts.UserFromAuth do
 
   defp name_from_auth(%Auth{info: %{name: name}}) when name != nil, do: name
 
-  defp name_from_auth(%Auth{info: info}) do
-    [info.first_name, info.last_name]
-    |> Enum.filter(&(&1 != nil and &1 != ""))
-    |> Enum.join(" ")
+  defp name_from_auth(%Auth{info: info} = auth) do
+    if is_nil(info.first_name) && is_nil(info.last_name) do
+      username_from_auth(auth)
+    else
+      [info.first_name, info.last_name]
+      |> Enum.filter(&(&1 != nil and &1 != ""))
+      |> Enum.join(" ")
+    end
   end
 
   defp username_from_auth(%Auth{info: %{nickname: nickname}}), do: nickname

--- a/test/adoptoposs/accounts/user_from_auth_test.exs
+++ b/test/adoptoposs/accounts/user_from_auth_test.exs
@@ -1,0 +1,56 @@
+defmodule Adoptoposs.Accounts.UserFromAuthTest do
+  use Adoptoposs.DataCase
+
+  import Adoptoposs.Factory
+
+  alias Adoptoposs.Accounts.UserFromAuth
+
+  test "build/1 builds user data from the passed Auth" do
+    auth = build(:auth)
+
+    assert UserFromAuth.build(auth) == %{
+             uid: auth.uid,
+             provider: auth.provider,
+             name: auth.info.name,
+             username: auth.info.nickname,
+             email: auth.info.email,
+             avatar_url: auth.info.urls.avatar_url,
+             profile_url: auth.info.urls.html_url,
+             settings: %{}
+           }
+  end
+
+  test "build/1 uses first_name & last_name if name is not available" do
+    auth = build(:auth)
+    info = %{auth.info | name: nil, first_name: "Peter", last_name: "Parker"}
+    auth = %{auth | info: info}
+
+    assert UserFromAuth.build(auth) == %{
+             uid: auth.uid,
+             provider: auth.provider,
+             name: "#{auth.info.first_name} #{auth.info.last_name}",
+             username: auth.info.nickname,
+             email: auth.info.email,
+             avatar_url: auth.info.urls.avatar_url,
+             profile_url: auth.info.urls.html_url,
+             settings: %{}
+           }
+  end
+
+  test "build/1 uses username as name if names are not available" do
+    auth = build(:auth)
+    info = %{auth.info | name: nil, first_name: nil, last_name: nil}
+    auth = %{auth | info: info}
+
+    assert UserFromAuth.build(auth) == %{
+             uid: auth.uid,
+             provider: auth.provider,
+             name: auth.info.nickname,
+             username: auth.info.nickname,
+             email: auth.info.email,
+             avatar_url: auth.info.urls.avatar_url,
+             profile_url: auth.info.urls.html_url,
+             settings: %{}
+           }
+  end
+end


### PR DESCRIPTION
Fixes #129 - a failing login bug for users who don't have a name set in their GitHub account. 

The Ecto validation failed for blank name attr, which was not handled and resulted in a failure of the auth callback which made the auth process restart in a loop.

It now just uses the GitHub username as name if no other (name, first_name, last_name) is available in the Ueberauth auth data.

