### PR TITLE
Add CI for staging deployment from testing & develop branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, testing ]
   pull_request:
     branches: [ main, develop ]
 
@@ -49,9 +49,16 @@ jobs:
     - name: Run tests
       run: make test
 
-  deploy:
+  deploy-develop:
+    needs: test
+    if: (github.ref == 'refs/heads/develop') || (github.ref == 'refs/heads/testing')
+    uses: ./.github/workflows/deployment-staging.yaml
+    secrets:
+      FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  deploy-main:
     needs: test
     if: github.ref == 'refs/heads/main'
-    uses: ./.github/workflows/deployment.yaml
+    uses: ./.github/workflows/deployment-production.yaml
     secrets:
       FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deployment-production.yaml
+++ b/.github/workflows/deployment-production.yaml
@@ -1,0 +1,19 @@
+name: Fly Deploy
+
+on:
+  workflow_call:
+    secrets:
+      FLY_API_TOKEN:
+        required: true
+
+jobs:
+  deploy:
+      name: production
+      runs-on: ubuntu-latest
+
+      steps:
+        - uses: actions/checkout@v3
+        - uses: superfly/flyctl-actions/setup-flyctl@master
+        - run: flyctl deploy --app adoptoposs --config ./fly.toml --remote-only
+          env:
+            FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deployment-staging.yaml
+++ b/.github/workflows/deployment-staging.yaml
@@ -8,12 +8,12 @@ on:
 
 jobs:
   deploy:
-      name: production
+      name: staging
       runs-on: ubuntu-latest
 
       steps:
         - uses: actions/checkout@v3
         - uses: superfly/flyctl-actions/setup-flyctl@master
-        - run: flyctl deploy --remote-only
+        - run: flyctl deploy --app adoptoposs-staging --config ./fly.staging.toml --remote-only
           env:
             FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.staging.toml
+++ b/fly.staging.toml
@@ -1,0 +1,41 @@
+app = "adoptoposs-staging"
+
+kill_signal = "SIGTERM"
+kill_timeout = 5
+processes = []
+
+[deploy]
+  release_command = "/app/bin/migrate"
+
+[env]
+  # put only not secret ENV variables here
+
+[experimental]
+  allowed_public_ports = []
+  auto_rollback = true
+
+[[services]]
+  http_checks = []
+  internal_port = 4000
+  processes = ["app"]
+  protocol = "tcp"
+  script_checks = []
+
+  [services.concurrency]
+    hard_limit = 25
+    soft_limit = 20
+    type = "connections"
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    grace_period = "20s" # allow some time for startup
+    interval = "15s"
+    restart_limit = 0
+    timeout = "2s"


### PR DESCRIPTION
Adds a staging environment and CI when pushing to the `develop` & `testing` branch.
The staging app is available at https://adoptoposs-staging.fly.dev and is secured by HTTP basic auth.