### PR TITLE
Add languages update job

### DIFF
--- a/config/dev.exs.sample
+++ b/config/dev.exs.sample
@@ -41,6 +41,10 @@ config :adoptoposs, :github_api, Adoptoposs.Network.Api.Github
 #     project_recommendations: [
 #       schedule: {:extended, "*/5 * * * * *"},
 #       task: {Adoptoposs.Jobs, :send_project_recommendations, []}
+#     ],
+#     languages_update: [
+#       schedule: {:extended, "*/30 * * * * *"},
+#       task: {Adoptoposs.Jobs, :fetch_languages, []}
 #     ]
 #   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -114,6 +114,11 @@ if config_env() == :prod do
         # default: every day, 4pm UTC
         schedule: System.get_env("CRONTAB_PROJECT_RECOMMENDATIONS") || "0 16 * * *",
         task: {Adoptoposs.Jobs, :send_project_recommendations, []}
+      ],
+      languages_update: [
+        # default: every Sunday, 2am UTC
+        schedule: System.get_env("CRONTAB_LANGUAGES_UPDATE") || "0 2 * * Sun",
+        task: {Adoptoposs.Jobs, :fetch_languages, []}
       ]
     ]
 

--- a/lib/adoptoposs/jobs.ex
+++ b/lib/adoptoposs/jobs.ex
@@ -44,6 +44,13 @@ defmodule Adoptoposs.Jobs do
     end
   end
 
+  @doc """
+  Fetches programming languages from GitHub's linguist repository
+  """
+  def fetch_languages do
+    Adoptoposs.Release.fetch_languages()
+  end
+
   defp email_weekday do
     System.get_env("EMAIL_WEEKDAY") || @default_email_weekday
   end


### PR DESCRIPTION
that runs every Sunday night (by default, unless configured otherwise by the `CRONTAB_LANGUAGES_UPDATE` env var)

Fixes #125