### PR TITLE
Use verified routes instead of Route helpers

### DIFF
--- a/lib/adoptoposs_web.ex
+++ b/lib/adoptoposs_web.ex
@@ -16,6 +16,8 @@ defmodule AdoptopossWeb do
   and import those modules here.
   """
 
+  def static_paths, do: ~w(assets fonts images favicon.ico robots.txt)
+
   def controller do
     quote do
       use Phoenix.Controller, namespace: AdoptopossWeb
@@ -23,6 +25,8 @@ defmodule AdoptopossWeb do
       import Plug.Conn
       import AdoptopossWeb.Gettext
       alias AdoptopossWeb.Router.Helpers, as: Routes
+
+      unquote(verified_routes())
     end
   end
 
@@ -97,6 +101,17 @@ defmodule AdoptopossWeb do
       import AdoptopossWeb.ErrorHelpers
       import AdoptopossWeb.Gettext
       alias AdoptopossWeb.Router.Helpers, as: Routes
+
+      unquote(verified_routes())
+    end
+  end
+
+  def verified_routes do
+    quote do
+      use Phoenix.VerifiedRoutes,
+        endpoint: AdoptopossWeb.Endpoint,
+        router: AdoptopossWeb.Router,
+        statics: AdoptopossWeb.static_paths()
     end
   end
 

--- a/lib/adoptoposs_web/controllers/repo_controller.ex
+++ b/lib/adoptoposs_web/controllers/repo_controller.ex
@@ -1,10 +1,8 @@
 defmodule AdoptopossWeb.RepoController do
   use AdoptopossWeb, :controller
 
-  alias AdoptopossWeb.RepoLive
-
   def index(conn, _params) do
     username = conn.assigns.current_user.username
-    redirect(conn, to: Routes.live_path(conn, RepoLive, username))
+    redirect(conn, to: ~p"/settings/repos/#{username}")
   end
 end

--- a/lib/adoptoposs_web/controllers/sharing_controller.ex
+++ b/lib/adoptoposs_web/controllers/sharing_controller.ex
@@ -1,9 +1,7 @@
 defmodule AdoptopossWeb.SharingController do
   use AdoptopossWeb, :controller
 
-  alias AdoptopossWeb.SharingLive
-
   def index(conn, %{"uuid" => uuid}) do
-    redirect(conn, to: Routes.live_path(conn, SharingLive, uuid))
+    redirect(conn, to: ~p"/projects/#{uuid}")
   end
 end

--- a/lib/adoptoposs_web/endpoint.ex
+++ b/lib/adoptoposs_web/endpoint.ex
@@ -22,7 +22,7 @@ defmodule AdoptopossWeb.Endpoint do
     from: :adoptoposs,
     gzip: true,
     brotli: true,
-    only: ~w(assets fonts images favicon.ico robots.txt)
+    only: AdoptopossWeb.static_paths()
 
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.

--- a/lib/adoptoposs_web/live/explore_live/components.ex
+++ b/lib/adoptoposs_web/live/explore_live/components.ex
@@ -39,7 +39,7 @@ defmodule AdoptopossWeb.ExploreLive.Components do
           Your favorite languages
           <%= if @user_id do %>
             <span class="float-right">
-              <.link navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)}>
+              <.link navigate={~p"/settings"}>
                 Edit
               </.link>
             </span>
@@ -125,7 +125,7 @@ defmodule AdoptopossWeb.ExploreLive.Components do
         Your favorite languages
         <%= if @user_id do %>
           <span class="float-right">
-            <.link navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)}>
+            <.link navigate={~p"/settings"}>
               Edit
             </.link>
           </span>
@@ -235,7 +235,7 @@ defmodule AdoptopossWeb.ExploreLive.Components do
             </div>
 
             <p class="mb-0">
-              <.link navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)}>
+              <.link navigate={~p"/settings"}>
                 Add your favorite languages
               </.link>
               in your settings.
@@ -243,19 +243,13 @@ defmodule AdoptopossWeb.ExploreLive.Components do
             </p>
           <% else %>
             <p class="mb-0">
-              ℹ You can follow your favorite languages in <.link navigate={
-                Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)
-              }>
-                your settings
-              </.link>.
+              <i class="fa-solid fa-circle-info mr-1.5"></i>
+              You can follow your favorite languages in <.link navigate={~p"/settings"}> your settings</.link>.
               They will appear here as quick filters.
             </p>
           <% end %>
         <% else %>
-          <.link
-            navigate={Routes.auth_path(AdoptopossWeb.Endpoint, :request, "github")}
-            class="button-link text-center mb-2"
-          >
+          <.link navigate={~p"/auth/github"} class="button-link text-center mb-2">
             <i class="fa-brands fa-github mr-1"></i> Log in with GitHub
           </.link>
 

--- a/lib/adoptoposs_web/live/explore_live/index.ex
+++ b/lib/adoptoposs_web/live/explore_live/index.ex
@@ -72,13 +72,25 @@ defmodule AdoptopossWeb.ExploreLive.Index do
 
   @impl true
   def handle_info({:force_update}, %{assigns: assigns} = socket) do
-    opts = %{q: assigns.query, f: assigns.filters}
-    {:noreply, push_redirect(socket, to: Routes.live_path(socket, __MODULE__, opts))}
+    params = clean_up_params(%{q: assigns.query, f: assigns.filters})
+    {:noreply, push_redirect(socket, to: ~p"/explore?#{params}")}
+  end
+
+  defp set_params(socket, %{}) do
+    push_patch(socket, to: ~p"/explore")
   end
 
   defp set_params(socket, opts) do
-    push_patch(socket, to: Routes.live_path(socket, __MODULE__, opts))
+    params = clean_up_params(opts)
+    push_patch(socket, to: ~p"/explore?#{params}")
   end
+
+  defp clean_up_params(q: nil, f: []), do: %{}
+  defp clean_up_params(q: "", f: []), do: %{}
+  defp clean_up_params(q: nil, f: filter), do: %{f: filter}
+  defp clean_up_params(q: "", f: filter), do: %{f: filter}
+  defp clean_up_params(q: query, f: []), do: %{q: query}
+  defp clean_up_params(params), do: params
 
   defp assign_defaults(socket, session, opts \\ []) do
     socket

--- a/lib/adoptoposs_web/live/landing_page_live.ex
+++ b/lib/adoptoposs_web/live/landing_page_live.ex
@@ -68,7 +68,7 @@ defmodule AdoptopossWeb.LandingPageLive do
     attrs = tags |> Enum.map(&%{user_id: user.id, tag_id: &1.id})
 
     Tags.create_tag_subscriptions(attrs)
-    {:noreply, push_redirect(socket, to: Routes.live_path(socket, __MODULE__))}
+    {:noreply, push_redirect(socket, to: ~p"/")}
   end
 
   defp apply_tag_filter(socket, _user, nil) do
@@ -84,8 +84,7 @@ defmodule AdoptopossWeb.LandingPageLive do
 
   defp push_tag_filter(socket, tag) do
     filter = String.downcase(tag.name)
-    path = Routes.live_path(socket, __MODULE__, f: filter)
-    push_patch(socket, to: path)
+    push_patch(socket, to: ~p"/?f=#{filter}")
   end
 
   defp put_assigns(socket, %User{} = user) do

--- a/lib/adoptoposs_web/live/repo_live.ex
+++ b/lib/adoptoposs_web/live/repo_live.ex
@@ -27,7 +27,7 @@ defmodule AdoptopossWeb.RepoLive do
 
   @impl true
   def handle_event("organization_selected", %{"id" => id}, socket) do
-    {:noreply, push_patch(socket, to: Routes.live_path(socket, __MODULE__, id))}
+    {:noreply, push_patch(socket, to: ~p"/settings/repos/#{id}")}
   end
 
   @impl true

--- a/lib/adoptoposs_web/plugs/require_login.ex
+++ b/lib/adoptoposs_web/plugs/require_login.ex
@@ -5,7 +5,8 @@ defmodule AdoptopossWeb.Plugs.RequireLogin do
 
   import Plug.Conn
   import Phoenix.Controller, only: [put_flash: 3, redirect: 2]
-  alias AdoptopossWeb.Router.Helpers, as: Routes
+
+  use AdoptopossWeb, :verified_routes
 
   alias Adoptoposs.Accounts.User
 
@@ -24,7 +25,7 @@ defmodule AdoptopossWeb.Plugs.RequireLogin do
   def call(conn, _opts) do
     conn
     |> put_flash(:error, "You need to log in to visit this page.")
-    |> redirect(to: Routes.live_path(conn, AdoptopossWeb.LandingPageLive))
+    |> redirect(to: ~p"/")
     |> halt()
   end
 end

--- a/lib/adoptoposs_web/templates/email/project_recommendations.html.heex
+++ b/lib/adoptoposs_web/templates/email/project_recommendations.html.heex
@@ -31,7 +31,7 @@
           <tr style="text-align:top;">
             <td style="padding: 18px 18px 6px 18px">
               <%= link(AdoptopossWeb.SharedView.project_name(project),
-                to: Routes.sharing_url(AdoptopossWeb.Endpoint, :index, project.uuid),
+                to: url(~p"/p/#{project.uuid}"),
                 class: "headline"
               ) %>
             </td>
@@ -65,10 +65,7 @@
 
       <mj-text css-class="text" align="center">
         <%= link("More #{language_name} projects…",
-          to:
-            Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.LandingPageLive,
-              f: String.downcase(language_name)
-            )
+          to: url(~p"/?f=#{String.downcase(language_name)}")
         ) %>
       </mj-text>
     <% end %>

--- a/lib/adoptoposs_web/templates/email/project_recommendations.text.eex
+++ b/lib/adoptoposs_web/templates/email/project_recommendations.text.eex
@@ -10,11 +10,11 @@ We’ve found some projects on Adoptoposs you might like to help maintain:
        @<%= project.user.username %> is looking for:
        <%= project.description %>
 
-    On Adoptoposs: <%= Routes.sharing_url(AdoptopossWeb.Endpoint, :index, project.uuid) %>
+    On Adoptoposs: <%= url(~p"/p/#{project.uuid}") %>
 
   <% end %>
 More <%= language_name %> projects on Adoptoposs:
-<%= Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.LandingPageLive, f: String.downcase(language_name)) %>
+<%= url(~p"/?f=#{String.downcase(language_name)}") %>
 
 ---------------------------------------------
 

--- a/lib/adoptoposs_web/templates/landing_page/index.html.heex
+++ b/lib/adoptoposs_web/templates/landing_page/index.html.heex
@@ -10,10 +10,7 @@
     <div class="flex flex-row items-center px-4 mt-16 md:px-0 md:mt-20">
       <hr class="flex-grow border-gray-50" />
       <div class="self-center">
-        <.link
-          navigate={Routes.live_path(@socket, AdoptopossWeb.ExploreLive.Index)}
-          class="button-link light mx-3"
-        >
+        <.link navigate={~p"/explore"} class="button-link light mx-3">
           Explore Projects
         </.link>
       </div>
@@ -49,10 +46,7 @@
 
     <div class="mt-4 grid grid-flow-row md:grid-cols-3 gap-6 md:gap-8">
       <div class="flex flex-col items-center">
-        <img
-          src={Routes.static_path(@socket, "/images/adoptoposs-submit.webp")}
-          class="mb-4 md:mb-6 h-48 md:h-auto"
-        />
+        <img src={~p"/images/adoptoposs-submit.webp"} class="mb-4 md:mb-6 h-48 md:h-auto" />
         <h2 class="text-center mb-2">Submit Your Repo</h2>
         <p class="text-lg text-hyphen md:text-xl max-w-sm mx-auto">
           You are looking for a co-maintainer?
@@ -63,10 +57,7 @@
       </div>
 
       <div class="flex flex-col items-center">
-        <img
-          src={Routes.static_path(@socket, "/images/adoptoposs-contact.webp")}
-          class="mb-4 md:mb-6 h-48 md:h-auto"
-        />
+        <img src={~p"/images/adoptoposs-contact.webp"} class="mb-4 md:mb-6 h-48 md:h-auto" />
         <h2 class="text-center text-gray-700 mb-2">Contact Maintainers</h2>
         <p class="text-lg text-hyphen md:text-xl max-w-sm mx-auto">
           You want to help with <acronym title="Open Source Software">OSS</acronym> maintenance?
@@ -76,10 +67,7 @@
       </div>
 
       <div class="flex flex-col items-center">
-        <img
-          src={Routes.static_path(@socket, "/images/adoptoposs-message.webp")}
-          class="mb-4 md:mb-6 h-48 md:h-auto"
-        />
+        <img src={~p"/images/adoptoposs-message.webp"} class="mb-4 md:mb-6 h-48 md:h-auto" />
         <h2 class="text-center text-red-400 mb-2">Explore Projects</h2>
         <p class="text-lg text-hyphen md:text-xl max-w-sm mx-auto">
           Not sure where to help?
@@ -92,10 +80,7 @@
     <div class="flex flex-row items-center px-4 mb-4 mt-12 md:px-0 md:mb-0 md:mt-20">
       <hr class="flex-grow border-gray-500" />
       <div class="self-center">
-        <.link
-          navigate={Routes.live_path(@socket, AdoptopossWeb.ExploreLive.Index)}
-          class="button-link dark mx-3 gray-500"
-        >
+        <.link navigate={~p"/explore"} class="button-link dark mx-3 gray-500">
           Explore Projects
         </.link>
       </div>
@@ -128,10 +113,7 @@
     </div>
 
     <div class="mt-12 text-center self-center">
-      <.link
-        navigate={Routes.live_path(@socket, AdoptopossWeb.ExploreLive.Index)}
-        class="button-link medium mx-3"
-      >
+      <.link navigate={~p"/explore"} class="button-link medium mx-3">
         Explore More…
       </.link>
     </div>
@@ -186,7 +168,7 @@
     <div class="flex flex-row items-center mt-12">
       <hr class="flex-grow border-red-200" />
       <div class="self-center">
-        <.link navigate={Routes.auth_path(@socket, :request, "github")} class="button-link mx-3">
+        <.link navigate={~p"/auth/github"} class="button-link mx-3">
           <i class="fa-brands fa-github mr-1"></i> Log in with GitHub
         </.link>
       </div>

--- a/lib/adoptoposs_web/templates/landing_page/recommendations.html.heex
+++ b/lib/adoptoposs_web/templates/landing_page/recommendations.html.heex
@@ -29,7 +29,7 @@
     ) %>
 
     <p>
-      <.link navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)}>
+      <.link navigate={~p"/settings"}>
         Add your favorite languages
       </.link>
       in your settings.<br /> Related projects will appear here.
@@ -55,10 +55,7 @@
     </div>
 
     <div class="ml-2 mt-1 text-center">
-      <.link
-        navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive)}
-        class="md:whitespace-nowrap"
-      >
+      <.link navigate={~p"/settings"} class="md:whitespace-nowrap">
         Edit Languages
       </.link>
     </div>
@@ -75,7 +72,7 @@
       </p>
       <p>
         Subscribe to
-        <.link navigate={Routes.live_path(@socket, AdoptopossWeb.SettingsLive)}>
+        <.link navigate={~p"/settings"}>
           email notifications
         </.link>
         and we’ll let you know if new ones come in.
@@ -94,9 +91,7 @@
     </div>
 
     <div class="text-center mt-6">
-      <.link navigate={
-        Routes.live_path(@socket, AdoptopossWeb.ExploreLive.Index, f: [@tag_filter])
-      }>
+      <.link navigate={~p"/explore/?#{[f: [@tag_filter]]}"}>
         Explore More…
       </.link>
     </div>

--- a/lib/adoptoposs_web/templates/layout/email.html.heex
+++ b/lib/adoptoposs_web/templates/layout/email.html.heex
@@ -75,10 +75,7 @@
           - The Adoptoposs Team
         </mj-text>
 
-        <mj-image
-          width="101px"
-          src={Routes.static_url(AdoptopossWeb.Endpoint, "/images/adoptoposs-logo.webp")}
-        />
+        <mj-image width="101px" src={url(~p"/images/adoptoposs-logo.webp")} />
       </mj-column>
     </mj-section>
     <!-- footer -->
@@ -86,7 +83,7 @@
       <mj-column>
         <mj-text color="white" font-size="12px" font-family="Source Sans Pro" align="center">
           Visit <%= link(AdoptopossWeb.Endpoint.host(),
-            to: Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.LandingPageLive),
+            to: url(~p"/"),
             class: "inline"
           ) %> to find co-maintainers for your open source software project.
         </mj-text>
@@ -98,10 +95,7 @@
           align="center"
           padding-top="0"
         >
-          You can <%= link("unsubscribe",
-            to: Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive),
-            class: "inline"
-          ) %> from these notifications in your account settings.
+          You can <%= link("unsubscribe", to: url(~p"/settings"), class: "inline") %> from these notifications in your account settings.
         </mj-text>
       </mj-column>
     </mj-section>

--- a/lib/adoptoposs_web/templates/layout/email.text.eex
+++ b/lib/adoptoposs_web/templates/layout/email.text.eex
@@ -5,5 +5,5 @@ Always keep maintaining!
 - The Adoptoposs Team
 
 
-Visit <%= Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.LandingPageLive) %> to find co-maintainers for your open source software project.
-You can unsubscribe from these notifications in your account settings: <%= Routes.live_url(AdoptopossWeb.Endpoint, AdoptopossWeb.SettingsLive) %>.
+Visit <%= url(~p"/") %> to find co-maintainers for your open source software project.
+You can unsubscribe from these notifications in your account settings: <%= url(~p"/settings") %>.

--- a/lib/adoptoposs_web/templates/layout/error.html.heex
+++ b/lib/adoptoposs_web/templates/layout/error.html.heex
@@ -6,11 +6,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <%= render(AdoptopossWeb.SharedView, "meta_tags.html", assigns) %>
 
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
+    <link rel="stylesheet" href={~p"/assets/app.css"} />
     <%= render(AdoptopossWeb.SharedView, "google_analytics.html") %>
 
     <%= csrf_meta_tag() %>
-    <script defer type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}>
+    <script defer type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
 
@@ -21,11 +21,7 @@
       <nav role="navigation">
         <div class="flex items-center shrink-0 mr-6">
           <a href="/" class="font-semibold text-xl tracking-tight">
-            <img
-              src={Routes.static_path(@conn, "/images/adoptoposs-logo.webp")}
-              alt="Adoptoposs"
-              class="h-10"
-            />
+            <img src={~p"/images/adoptoposs-logo.webp"} alt="Adoptoposs" class="h-10" />
           </a>
         </div>
 

--- a/lib/adoptoposs_web/templates/layout/root.html.heex
+++ b/lib/adoptoposs_web/templates/layout/root.html.heex
@@ -9,11 +9,11 @@
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <link rel="icon" href="/favicon.ico" type="image/x-icon" />
 
-    <link rel="stylesheet" href={Routes.static_path(@conn, "/assets/app.css")} />
+    <link rel="stylesheet" href={~p"/assets/app.css"} />
     <%= render(AdoptopossWeb.SharedView, "google_analytics.html") %>
 
     <%= csrf_meta_tag() %>
-    <script defer type="text/javascript" src={Routes.static_path(@conn, "/assets/app.js")}>
+    <script defer type="text/javascript" src={~p"/assets/app.js"}>
     </script>
   </head>
 

--- a/lib/adoptoposs_web/templates/messages/contacted.html.heex
+++ b/lib/adoptoposs_web/templates/messages/contacted.html.heex
@@ -5,7 +5,7 @@
 
   <div class="flex md:hidden flex-col pb-4 bg-gray-50 sticky top-0">
     <.link
-      navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.MessagesLive.Interests)}
+      navigate={~p"/messages/interests"}
       class="flex items-center w-full font-semibold cursor-default pl-6 pt-3 pb-2 rounded cursor-pointer focus:bg-gray-200 text-gray-600 hover:text-gray-700 focus:text-gray-700"
     >
       Interests in your Projects
@@ -24,10 +24,7 @@
           <p class="text-lg md:text-2xl text-gray-500 text-center mb-4 md:mb-8">
             You did not contact any maintainer yet.
           </p>
-          <.link
-            navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.ExploreLive.Index)}
-            class="button-link mb-4"
-          >
+          <.link navigate={~p"/explore"} class="button-link mb-4">
             Explore Projects
           </.link>
           <p>
@@ -84,7 +81,7 @@
 
     <div class="hidden md:flex md:flex-col w-1/4 ml-8 border rounded border-gray-300">
       <.link
-        navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.MessagesLive.Interests)}
+        navigate={~p"/messages/interests"}
         class="flex items-center w-full pl-10 font-semibold cursor-default p-3 rounded cursor-pointer bg-white hover:bg-gray-100 focus:bg-gray-200 text-gray-600 hover:text-gray-700 focus:text-gray-700"
       >
         Interests in your Projects

--- a/lib/adoptoposs_web/templates/messages/interests.html.heex
+++ b/lib/adoptoposs_web/templates/messages/interests.html.heex
@@ -10,7 +10,7 @@
     </div>
 
     <.link
-      navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.MessagesLive.Contacted)}
+      navigate={~p"/messages/contacted"}
       class="flex items-center w-full font-semibold cursor-default pl-6 pt-1 pb-2 rounded cursor-pointer focus:bg-gray-200 text-gray-600 hover:text-gray-700 focus:text-gray-700"
     >
       Contacted Maintainers
@@ -26,7 +26,7 @@
           </p>
           <p>
             Hint: Share your
-            <.link navigate={Routes.live_path(@socket, AdoptopossWeb.ProjectLive)}>
+            <.link navigate={~p"/settings/projects"}>
               submitted projects
             </.link>
             to let more people know you’re looking for help.
@@ -110,7 +110,7 @@
       </div>
 
       <.link
-        navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.MessagesLive.Contacted)}
+        navigate={~p"/messages/contacted"}
         class="flex items-center w-full pl-10 font-semibold cursor-default p-3 rounded cursor-pointer bg-white hover:bg-gray-100 focus:bg-gray-200 text-gray-600 hover:text-gray-700 focus:text-gray-700"
       >
         Contacted Maintainers

--- a/lib/adoptoposs_web/templates/page/faq.html.heex
+++ b/lib/adoptoposs_web/templates/page/faq.html.heex
@@ -50,7 +50,7 @@
     <%= faq "How can I submit my repo?"  do %>
       <ul class="list-disc list-inner pl-4">
         <li>
-          You can submit a repo on your <.link navigate={Routes.repo_path(@conn, :index)}>repo page</.link>.
+          You can submit a repo on your <.link navigate={~p"/settings/repos"}>repo page</.link>.
         </li>
         <li>
           Select the GitHub organization of your repo at the top of the page.
@@ -67,10 +67,8 @@
 
     <%= faq "Where can I see my submitted repos?" do %>
       Your submitted repositories are listed on your
-      <.link navigate={Routes.live_path(@conn, AdoptopossWeb.ProjectLive)}>projects page</.link>
-      and visible for everyone on the <.link navigate={
-        Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)
-      }>
+      <.link navigate={~p"/settings/projects"}>projects page</.link>
+      and visible for everyone on the <.link navigate={~p"/explore"}>
         public explore page
       </.link>.
     <% end %>
@@ -85,12 +83,12 @@
     <%= faq "How can I become a maintainer for a project on Adoptoposs?" do %>
       <p>
         Projects that are looking for maintainers are visible on the
-        <.link navigate={Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)}>
+        <.link navigate={~p"/explore"}>
           explore page
         </.link>
         or your personal
         <%= if @current_user do %>
-          <.link navigate={Routes.live_path(@conn, AdoptopossWeb.LandingPageLive)}>
+          <.link navigate={~p"/"}>
             dashboard
           </.link>
         <% else %>
@@ -107,16 +105,14 @@
 
     <%= faq "How can I find interesting projects?" do %>
       <p>
-        You will find projects on our <.link navigate={
-          Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)
-        }>explore page</.link>.
+        You will find projects on our <.link navigate={~p"/explore"}>explore page</.link>.
         You can search for project names, organizations, and parts of the maintainer’s description. You can filter all projects by selecting the languages you are interested in.
       </p>
 
       <p>
         If you added favorite programming languages you will see project recommendations on your personal
         <%= if @current_user do %>
-          <.link navigate={Routes.live_path(@conn, AdoptopossWeb.LandingPageLive)}>
+          <.link navigate={~p"/"}>
             dashboard
           </.link>
         <% else %>
@@ -124,8 +120,7 @@
         <% end %>.
       </p>
       <p>
-        You can also
-        <.link navigate={Routes.live_path(@conn, AdoptopossWeb.SettingsLive)}>subscribe</.link>
+        You can also <.link navigate={~p"/settings"}>subscribe</.link>
         to email notifications to receive project recommendations for your favourite languages.
       </p>
     <% end %>
@@ -150,9 +145,7 @@
 
     <%= faq "How can I subscribe to / unsubscribe from email notifications?" do %>
       <p>
-        You can edit your email notification settings on your <.link navigate={
-          Routes.live_path(@conn, AdoptopossWeb.SettingsLive)
-        }>
+        You can edit your email notification settings on your <.link navigate={~p"/settings"}>
           settings page
         </.link>.
       </p>

--- a/lib/adoptoposs_web/templates/project/index.html.heex
+++ b/lib/adoptoposs_web/templates/project/index.html.heex
@@ -10,10 +10,7 @@
         <p>
           Looking for a maintainer?
         </p>
-        <%= link("Submit Repo",
-          to: Routes.repo_path(AdoptopossWeb.Endpoint, :index),
-          class: "button-link mb-4"
-        ) %>
+        <%= link("Submit Repo", to: ~p"/settings/repos", class: "button-link mb-4") %>
         <p>
           Submitted Repos will appear here.
         </p>
@@ -133,7 +130,7 @@
                       </div>
                     <% else %>
                       <.link
-                        navigate={Routes.live_path(@socket, AdoptopossWeb.MessagesLive.Interests) <> "/#p-#{project.uuid}"}
+                        navigate={~p"/messages/interests?p-#{project.uuid}"}
                         class="flex flex-row items-center emphasize"
                         title={"#{Enum.count(project.interests)} people contacted you"}
                       >

--- a/lib/adoptoposs_web/templates/project/sharing.html.heex
+++ b/lib/adoptoposs_web/templates/project/sharing.html.heex
@@ -17,7 +17,7 @@
       <input
         type="text"
         readonly
-        value={Routes.sharing_url(AdoptopossWeb.Endpoint, :index, @project.uuid)}
+        value={url(~p"/p/#{@project.uuid}")}
         class="flex-grow px-2 py-1 rounded border border-gray-200"
         data-copy-target
       />

--- a/lib/adoptoposs_web/templates/repo/repo.html.heex
+++ b/lib/adoptoposs_web/templates/repo/repo.html.heex
@@ -12,7 +12,7 @@
         <span class="text-gray-500 mr-4 md:mb-2">
           Submitted to
           <.link
-            navigate={Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.ProjectLive)}
+            navigate={~p"/settings/projects"}
             class="text-gray-500 hover:text-gray-600 underline"
           >
             Your Projects

--- a/lib/adoptoposs_web/templates/settings/index.html.heex
+++ b/lib/adoptoposs_web/templates/settings/index.html.heex
@@ -9,7 +9,7 @@
         <p class="">
           <i class="fa-solid fa-circle-info mr-1.5"></i>
           Programming languages you add here will appear as quick filters on the <.link navigate={
-            Routes.live_path(AdoptopossWeb.Endpoint, AdoptopossWeb.ExploreLive.Index)
+            ~p"/explore"
           }>
             explore projects page
           </.link>.

--- a/lib/adoptoposs_web/templates/shared/meta_tags.html.heex
+++ b/lib/adoptoposs_web/templates/shared/meta_tags.html.heex
@@ -1,6 +1,6 @@
 <% title = AdoptopossWeb.SharingView.title(assigns) %>
 <% description = AdoptopossWeb.SharingView.description(assigns) %>
-<% image = AdoptopossWeb.SharingView.image(assigns) %>
+<% image = url(~p"/images/adoptoposs-social.jpg") %>
 <% url = AdoptopossWeb.SharingView.url(assigns) %>
 <% twitter_card_type = AdoptopossWeb.SharingView.twitter_card_type(assigns) %>
 

--- a/lib/adoptoposs_web/templates/shared/navigation.html.heex
+++ b/lib/adoptoposs_web/templates/shared/navigation.html.heex
@@ -1,14 +1,14 @@
 <nav role="navigation" class="flex flex-row flex-wrap justify-between items-center">
   <div class="flex items-center shrink-0 mr-2 sm:mr-6">
-    <.link navigate={Routes.live_path(@conn, AdoptopossWeb.LandingPageLive)} class="h-10">
+    <.link navigate={~p"/"} class="h-10">
       <img
-        src={Routes.static_path(@conn, "/images/adoptoposs-logo.webp")}
+        src={~p"/images/adoptoposs-logo.webp"}
         alt="Adoptoposs"
         class="h-10 hidden xs:inline-block"
       />
 
       <div
-        style={"background-image: url(#{Routes.static_path(@conn, "/images/adoptoposs-logo.webp")})"}
+        style={"background-image: url(#{~p"/images/adoptoposs-logo.webp"})"}
         alt="Adoptoposs"
         class="h-10 w-10 bg-no-repeat bg-cover bg-right bg-origin-content xs:hidden inline-block"
       />

--- a/lib/adoptoposs_web/templates/shared/navigation_logged_in.html.heex
+++ b/lib/adoptoposs_web/templates/shared/navigation_logged_in.html.heex
@@ -1,7 +1,7 @@
 <!-- hidden on mobile -->
 <div class="md:hidden inline-block">
   <.link
-    navigate={Routes.live_path(@conn, AdoptopossWeb.RepoLive, @current_user.username)}
+    navigate={~p"/settings/repos/#{@current_user.username}"}
     class="self-center text-md px-4 py-2 leading-none border border-red-300 rounded font-semibold"
   >
     <i class="fa-solid fa-plus mr-1.5"></i> Submit Repo
@@ -14,10 +14,7 @@
   </summary>
 
   <div class="toggle-content absolute left-0 right-0 bg-gray-50 z-20 shadow-md p-6">
-    <.link
-      navigate={Routes.live_path(@conn, AdoptopossWeb.MessagesLive.Interests)}
-      class="nav-link"
-    >
+    <.link navigate={~p"/messages/interests"} class="nav-link">
       <%= if @notification_count > 0 do %>
         <i class="fa-solid fa-envelope-open-text mr-2"></i>
       <% else %>
@@ -26,23 +23,23 @@
       Messages
     </.link>
 
-    <.link navigate={Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)} class="nav-link">
+    <.link navigate={~p"/explore"} class="nav-link">
       <i class="fa-solid fa-magnifying-glass mr-2"></i>
       <span class="inline">Explore</span>
     </.link>
 
-    <.link navigate={Routes.live_path(@conn, AdoptopossWeb.ProjectLive)} class="nav-link">
+    <.link navigate={~p"/settings/projects"} class="nav-link">
       <i class="fa-solid fa-list mr-2"></i> Your Projects
     </.link>
 
-    <.link navigate={Routes.live_path(@conn, AdoptopossWeb.SettingsLive)} class="nav-link">
+    <.link navigate={~p"/settings"} class="nav-link">
       <i class="fa-solid fa-gear mr-2"></i> Settings
     </.link>
 
     <hr class="border-red-100 mt-4 mb-3" />
 
     <div class=" flex flex-row justify-between items-center">
-      <.link navigate={Routes.auth_path(@conn, :delete)} class="nav-link flex-grow mr-2">
+      <.link navigate={~p"/logout"} class="nav-link flex-grow mr-2">
         <i class="fa-solid fa-arrow-right-from-bracket mr-2"></i> Log out
       </.link>
 
@@ -56,10 +53,7 @@
   class="hidden w-full text-md md:flex-grow justify-end md:flex md:flex-row md:items-end md:w-auto md:items-center mt-4 md:mt-0"
 >
   <div class="hidden md:inline-flex">
-    <.link
-      navigate={Routes.live_path(@conn, AdoptopossWeb.MessagesLive.Interests)}
-      class="flex items-center p-2 mr-4 font-semibold"
-    >
+    <.link navigate={~p"/messages/interests"} class="flex items-center p-2 mr-4 font-semibold">
       <span class="flex relative items-center">
         <%= if @notification_count > 0 do %>
           <i class="fa-solid fa-envelope-open-text mr-2"></i>
@@ -72,16 +66,13 @@
       </span>
     </.link>
 
-    <.link
-      navigate={Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)}
-      class="flex items-center p-2 mr-4"
-    >
+    <.link navigate={~p"/explore"} class="flex items-center p-2 mr-4">
       <i class="fa-solid fa-magnifying-glass mr-2"></i>
       <span class="inline font-semibold">Explore</span>
     </.link>
 
     <.link
-      navigate={Routes.live_path(@conn, AdoptopossWeb.RepoLive, @current_user.username)}
+      navigate={~p"/settings/repos/#{@current_user.username}"}
       class="flex self-center button-link subtle mr-4"
     >
       <i class="fa-solid fa-plus mr-1.5"></i> Submit Repo
@@ -100,23 +91,17 @@
 
       <div class="relative">
         <div class="toggle-content absolute right-0 left-auto py-2 mt-2 rounded border border-red-200 bg-gray-50 shadow-md w-max-content font-semibold">
-          <.link
-            navigate={Routes.live_path(@conn, AdoptopossWeb.ProjectLive)}
-            class="group nav-link"
-          >
+          <.link navigate={~p"/settings/projects"} class="group nav-link">
             <i class="fa-solid fa-list mr-2"></i> Your Projects
           </.link>
 
-          <.link
-            navigate={Routes.live_path(@conn, AdoptopossWeb.SettingsLive)}
-            class="group nav-link"
-          >
+          <.link navigate={~p"/settings"} class="group nav-link">
             <i class="fa-solid fa-gear mr-2"></i> Settings
           </.link>
 
           <hr class="border-red-100 border mt-2 mb-1" />
 
-          <.link navigate={Routes.auth_path(@conn, :delete)} class="group nav-link">
+          <.link navigate={~p"/logout"} class="group nav-link">
             <i class="fa-solid fa-arrow-right-from-bracket mr-2"></i> Log out
           </.link>
         </div>

--- a/lib/adoptoposs_web/templates/shared/navigation_logged_out.html.heex
+++ b/lib/adoptoposs_web/templates/shared/navigation_logged_out.html.heex
@@ -1,14 +1,11 @@
 <div class="flex flex-row items-center">
-  <.link
-    navigate={Routes.live_path(@conn, AdoptopossWeb.ExploreLive.Index)}
-    class="flex items-center p-2 mr-4"
-  >
+  <.link navigate={~p"/explore"} class="flex items-center p-2 mr-4">
     <i class="fa-solid fa-magnifying-glass mr-2"></i>
     <span class="hidden sm:inline font-semibold">Explore</span>
   </.link>
 
   <div class="inline-block">
-    <.link navigate={Routes.auth_path(@conn, :request, "github")} class="button-link subtle">
+    <.link navigate={~p"/auth/github"} class="button-link subtle">
       <i class="fa-brands fa-github mr-1"></i> Log in with GitHub
     </.link>
   </div>

--- a/lib/adoptoposs_web/templates/sharing/project.html.heex
+++ b/lib/adoptoposs_web/templates/sharing/project.html.heex
@@ -27,7 +27,7 @@
     <% end %>
 
     <div class="mt-6 text-center text-lg">
-      <.link navigate={Routes.live_path(@socket, AdoptopossWeb.ExploreLive.Index)}>
+      <.link navigate={~p"/explore"}>
         Explore more projects
       </.link>
     </div>
@@ -36,7 +36,7 @@
       <div class="flex flex-row items-center my-6 md:my-8 mt-12 md:mt-16">
         <hr class="flex-grow border-red-200" />
         <div class="self-center">
-          <.link navigate={Routes.auth_path(@socket, :request, "github")} class="button-link mx-3">
+          <.link navigate={~p"/auth/github"} class="button-link mx-3">
             <i class="fa-brands fa-github mr-1"></i> Log in with GitHub
           </.link>
         </div>

--- a/lib/adoptoposs_web/views/layout_view.ex
+++ b/lib/adoptoposs_web/views/layout_view.ex
@@ -13,6 +13,6 @@ defmodule AdoptopossWeb.LayoutView do
   def email_footer_background(_email_type), do: "#f56565"
 
   defp image_url(image_name) do
-    Routes.static_url(AdoptopossWeb.Endpoint, "/images/#{image_name}")
+    url(~p"/images/#{image_name}")
   end
 end

--- a/lib/adoptoposs_web/views/sharing_view.ex
+++ b/lib/adoptoposs_web/views/sharing_view.ex
@@ -24,10 +24,6 @@ defmodule AdoptopossWeb.SharingView do
     project.data["owner"]["avatar_url"]
   end
 
-  def image(assigns) do
-    Routes.static_url(assigns.conn, "/images/adoptoposs-social.jpg")
-  end
-
   def url(assigns) do
     Plug.Conn.request_url(assigns.conn)
   end

--- a/test/adoptoposs_web/controllers/page_controller_test.exs
+++ b/test/adoptoposs_web/controllers/page_controller_test.exs
@@ -2,20 +2,20 @@ defmodule AdoptopossWeb.PageControllerTest do
   use AdoptopossWeb.ConnCase
 
   test "GET /faq", %{conn: conn} do
-    conn = get(conn, Routes.page_path(conn, :faq))
+    conn = get(conn, ~p"/faq")
     assert html_response(conn, 200) =~ "Frequently Asked Questions"
   end
 
   test "GET /privacy", %{conn: conn} do
-    conn = get(conn, Routes.page_path(conn, :privacy))
+    conn = get(conn, ~p"/privacy")
     assert html_response(conn, 200) =~ "Privacy Policy"
   end
 
   @tag login_as: "user123"
   test "page paths are visible for logged in users", %{conn: conn} do
-    [:faq, :privacy]
-    |> Enum.each(fn action ->
-      conn = get(conn, Routes.page_path(conn, action))
+    [~p"/faq", ~p"/privacy"]
+    |> Enum.each(fn path ->
+      conn = get(conn, path)
       assert html_response(conn, 200)
     end)
   end

--- a/test/adoptoposs_web/controllers/repo_controller_test.exs
+++ b/test/adoptoposs_web/controllers/repo_controller_test.exs
@@ -2,17 +2,16 @@ defmodule AdoptopossWeb.RepoControllerTest do
   use AdoptopossWeb.ConnCase
 
   test "GET /settings/repos requires authentication", %{conn: conn} do
-    conn = get(conn, Routes.repo_path(conn, :index))
-    path = Routes.live_path(conn, AdoptopossWeb.LandingPageLive)
+    conn = get(conn, ~p"/settings/repos")
 
-    assert redirected_to(conn, 302) == path
+    assert redirected_to(conn, 302) == ~p"/"
     assert conn.halted
   end
 
   @tag login_as: "user123"
   test "GET /settings/repos redirects to repo live path", %{conn: conn, user: user} do
-    conn = get(conn, Routes.repo_path(conn, :index))
-    path = Routes.live_path(conn, AdoptopossWeb.RepoLive, user.username)
+    conn = get(conn, ~p"/settings/repos")
+    path = ~p"/settings/repos/#{user.username}"
 
     assert redirected_to(conn, 302) == path
   end

--- a/test/adoptoposs_web/controllers/sharing_controller_test.exs
+++ b/test/adoptoposs_web/controllers/sharing_controller_test.exs
@@ -1,20 +1,18 @@
 defmodule AdoptopossWeb.SharingControllerTest do
   use AdoptopossWeb.ConnCase
 
-  alias AdoptopossWeb.SharingLive
-
   describe "GET /p/:uuid" do
     @uuid "uuid"
 
     test "is redirected for logged out users", %{conn: conn} do
-      conn = get(conn, Routes.sharing_path(conn, :index, @uuid))
-      assert redirected_to(conn, 302) =~ Routes.live_path(conn, SharingLive, @uuid)
+      conn = get(conn, ~p"/p/#{@uuid}")
+      assert redirected_to(conn, 302) =~ ~p"/projects/#{@uuid}"
     end
 
     @tag login_as: "user123"
     test "is redirected for logged in users", %{conn: conn} do
-      conn = get(conn, Routes.sharing_path(conn, :index, @uuid))
-      assert redirected_to(conn, 302) =~ Routes.live_path(conn, SharingLive, @uuid)
+      conn = get(conn, ~p"/p/#{@uuid}")
+      assert redirected_to(conn, 302) =~ ~p"/projects/#{@uuid}"
     end
   end
 end

--- a/test/adoptoposs_web/live/explore_live_test.exs
+++ b/test/adoptoposs_web/live/explore_live_test.exs
@@ -2,28 +2,27 @@ defmodule AdoptopossWeb.ExploreLiveTest do
   use AdoptopossWeb.LiveCase
   use Bamboo.Test, shared: true
 
-  alias AdoptopossWeb.ExploreLive
   alias Adoptoposs.{Communication.Interest, Tags.Tag}
 
   test "disconnected mount of /explore when logged out", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, ExploreLive.Index))
+    conn = get(conn, ~p"/explore")
     assert html_response(conn, 200) =~ "Explore Projects"
   end
 
   test "connected mount of /explore when logged out", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, ExploreLive.Index))
+    {:ok, _view, html} = live(conn, ~p"/explore")
     assert html =~ "Explore Projects"
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /explore when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, ExploreLive.Index))
+    conn = get(conn, ~p"/explore")
     assert html_response(conn, 200) =~ "Explore Projects"
   end
 
   @tag login_as: "user123"
   test "connected mount of /explore when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, ExploreLive.Index))
+    {:ok, _view, html} = live(conn, ~p"/explore")
     assert html =~ "Explore Projects"
   end
 
@@ -32,7 +31,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     project_1 = insert(:project, name: "Abcdefg", language: language)
     project_2 = insert(:project, name: "Hijklmn", language: language)
 
-    path = Routes.live_path(conn, ExploreLive.Index)
+    path = ~p"/explore"
 
     {:ok, view, _html} = live(conn, path)
     html = render_change(view, :search, %{q: project_1.name})
@@ -59,7 +58,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     project_2 = insert(:project, name: "Hijklmn", language: language_2)
     project_3 = insert(:project, name: "Opqrstu", language: language_3)
 
-    path = Routes.live_path(conn, ExploreLive.Index)
+    path = ~p"/explore"
     {:ok, view, html} = live(conn, path)
 
     # all projects are shown by default
@@ -80,7 +79,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     html = render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: [language_1.id]))
+    assert_patched(view, ~p"/explore?#{[f: [language_1.id]]}")
 
     assert html =~ project_1.name
     refute html =~ project_2.name
@@ -94,7 +93,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     html = render(view)
 
     filters = [language_2.id, language_1.id]
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: filters))
+    assert_patched(view, ~p"/explore?#{[f: filters]}")
 
     assert html =~ project_1.name
     assert html =~ project_2.name
@@ -108,7 +107,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     html = render(view)
 
     filters = [language_2.id]
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: filters))
+    assert_patched(view, ~p"/explore?#{[f: filters]}")
 
     refute html =~ project_1.name
     assert html =~ project_2.name
@@ -120,7 +119,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     html = render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: []))
+    assert_patched(view, ~p"/explore")
 
     assert html =~ project_1.name
     assert html =~ project_2.name
@@ -138,7 +137,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     language = insert(:tag, type: Tag.Language.type(), name: "Elixir")
     other_project = insert(:project, name: "Abcdefg", language: language)
 
-    path = Routes.live_path(conn, ExploreLive.Index)
+    path = ~p"/explore"
     {:ok, view, _html} = live(conn, path)
 
     # load more to see all created projects
@@ -165,7 +164,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     html = render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: [language.id]))
+    assert_patched(view, ~p"/explore?#{[f: [language.id]]}")
 
     assert html =~ other_project.name
 
@@ -183,7 +182,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: []))
+    assert_patched(view, ~p"/explore")
 
     # load more to see all created projects
     html = render_hook(view, :load_more)
@@ -206,7 +205,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
 
     insert(:tag_subscription, tag: language_1, user: user)
 
-    path = Routes.live_path(conn, ExploreLive.Index)
+    path = ~p"/explore"
     {:ok, view, html} = live(conn, path)
 
     filter_section_id = "filters-sidebar-subscribed"
@@ -225,7 +224,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     html = render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: [language_1.id]))
+    assert_patched(view, ~p"/explore?#{[f: [language_1.id]]}")
 
     assert html =~ project_1.name
     refute html =~ project_2.name
@@ -236,7 +235,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
     |> render_click()
 
     html = render(view)
-    assert_patched(view, Routes.live_path(conn, ExploreLive.Index, q: nil, f: []))
+    assert_patched(view, ~p"/explore")
 
     assert html =~ project_1.name
     assert html =~ project_2.name
@@ -244,7 +243,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
 
   test "contacting a project when logged out", %{conn: conn} do
     project = insert(:project)
-    {:ok, view, _html} = live(conn, Routes.live_path(conn, ExploreLive.Index))
+    {:ok, view, _html} = live(conn, ~p"/explore")
 
     html = render_change(view, :search, %{q: project.name})
     assert html =~ project.name
@@ -255,7 +254,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
   test "contacting a project when logged in", %{conn: conn, user: user} do
     project = insert(:project, user: build(:user, username: "other-user-than-logged-in"))
 
-    {:ok, view, _html} = live(conn, Routes.live_path(conn, ExploreLive.Index))
+    {:ok, view, _html} = live(conn, ~p"/explore")
 
     html = render_change(view, :search, %{q: project.name})
     assert html =~ project.name
@@ -288,7 +287,7 @@ defmodule AdoptopossWeb.ExploreLiveTest do
   test "contacting your own project when logged in is not possible", %{conn: conn, user: user} do
     project = insert(:project, user: user)
 
-    {:ok, view, _html} = live(conn, Routes.live_path(conn, ExploreLive.Index))
+    {:ok, view, _html} = live(conn, ~p"/explore")
 
     html = render_change(view, :search, %{q: project.name})
     assert html =~ project.name

--- a/test/adoptoposs_web/live/landing_page_live_test.exs
+++ b/test/adoptoposs_web/live/landing_page_live_test.exs
@@ -1,12 +1,11 @@
 defmodule AdoptopossWeb.LandingPageLiveTest do
   use AdoptopossWeb.LiveCase
 
-  alias AdoptopossWeb.LandingPageLive
   alias Adoptoposs.{Tags, Network}
   alias Adoptoposs.Tags.Tag
 
   test "disconnected mount when logged out", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, LandingPageLive))
+    conn = get(conn, ~p"/")
 
     html = html_response(conn, 200)
     assert html =~ "Find new (co-)maintainers"
@@ -14,7 +13,7 @@ defmodule AdoptopossWeb.LandingPageLiveTest do
   end
 
   test "disconnected mount when logged out with query params", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, LandingPageLive, f: "something"))
+    conn = get(conn, ~p"/?f=something")
 
     html = html_response(conn, 200)
     assert html =~ "Find new (co-)maintainers"
@@ -23,7 +22,7 @@ defmodule AdoptopossWeb.LandingPageLiveTest do
 
   @tag login_as: "user123"
   test "disconnected mount when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, LandingPageLive))
+    conn = get(conn, ~p"/")
 
     html = html_response(conn, 200)
     assert html =~ "Your Dashboard"
@@ -31,20 +30,20 @@ defmodule AdoptopossWeb.LandingPageLiveTest do
   end
 
   test "connected mount when logged out", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, LandingPageLive))
+    {:ok, _view, html} = live(conn, ~p"/")
     assert html =~ "Find new (co-)maintainers"
   end
 
   @tag login_as: "user123"
   test "connected mount when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, LandingPageLive))
+    {:ok, _view, html} = live(conn, ~p"/")
     assert html =~ "Your Dashboard"
   end
 
   @tag login_as: "user123"
   test "adding suggested languages", %{conn: conn, user: user} do
     insert_tags(user.provider)
-    {:ok, view, html} = live(conn, Routes.live_path(conn, LandingPageLive))
+    {:ok, view, html} = live(conn, ~p"/")
 
     assert html =~ "Add these languages"
     assert Enum.count(Tags.list_user_tag_subscriptions(user)) == 0
@@ -57,7 +56,7 @@ defmodule AdoptopossWeb.LandingPageLiveTest do
   @tag login_as: "user123"
   test "filtering recommendations by language", %{conn: conn, user: user} do
     tag_subscriptions = insert_list(2, :tag_subscription, user: user)
-    {:ok, view, html} = live(conn, Routes.live_path(conn, LandingPageLive))
+    {:ok, view, html} = live(conn, ~p"/")
 
     for tag_subscription <- tag_subscriptions do
       assert html =~ tag_subscription.tag.name

--- a/test/adoptoposs_web/live/messages_live_test.exs
+++ b/test/adoptoposs_web/live/messages_live_test.exs
@@ -3,13 +3,11 @@ defmodule AdoptopossWeb.MessagesLiveTest do
 
   import Adoptoposs.Factory
 
-  alias AdoptopossWeb.MessagesLive
-
   test "disconnected mount requires authentication on all messages routes", %{conn: conn} do
     Enum.each(
       [
-        Routes.live_path(conn, MessagesLive.Contacted),
-        Routes.live_path(conn, MessagesLive.Interests)
+        ~p"/messages/contacted",
+        ~p"/messages/interests"
       ],
       fn path ->
         conn = get(conn, path)
@@ -22,8 +20,8 @@ defmodule AdoptopossWeb.MessagesLiveTest do
   test "connected mount requires authentication on all project routes", %{conn: conn} do
     Enum.each(
       [
-        Routes.live_path(conn, MessagesLive.Contacted),
-        Routes.live_path(conn, MessagesLive.Interests)
+        ~p"/messages/contacted",
+        ~p"/messages/interests"
       ],
       fn path ->
         {:error, {:redirect, %{to: "/"}}} = live(conn, path)
@@ -33,25 +31,25 @@ defmodule AdoptopossWeb.MessagesLiveTest do
 
   @tag login_as: "user123"
   test "disconnected mount of /messages/contacted shows the page when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, MessagesLive.Contacted))
+    conn = get(conn, ~p"/messages/contacted")
     assert html_response(conn, 200) =~ "Contacted Maintainers"
   end
 
   @tag login_as: "user123"
   test "connected mount of /messages/contacted shows the page when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Contacted))
+    {:ok, _view, html} = live(conn, ~p"/messages/contacted")
     assert html =~ "Contacted Maintainers"
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /messages/interests shows the page when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, MessagesLive.Interests))
+    conn = get(conn, ~p"/messages/interests")
     assert html_response(conn, 200) =~ "Interests in your Projects"
   end
 
   @tag login_as: "user123"
   test "connected mount of /messages/interests shows the page when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Interests))
+    {:ok, _view, html} = live(conn, ~p"/messages/interests")
     assert html =~ "Interests in your Projects"
   end
 
@@ -62,13 +60,13 @@ defmodule AdoptopossWeb.MessagesLiveTest do
   } do
     message = "Dear maintainer, how can I help? :)"
     insert(:interest, creator: user, message: message)
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Contacted))
+    {:ok, _view, html} = live(conn, ~p"/messages/contacted")
     assert html =~ message
   end
 
   @tag login_as: "user123"
   test "/messages/contacted shows an empty message if no interests where sent yet", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Contacted))
+    {:ok, _view, html} = live(conn, ~p"/messages/contacted")
     assert html =~ "You did not contact any maintainer yet."
   end
 
@@ -81,7 +79,7 @@ defmodule AdoptopossWeb.MessagesLiveTest do
     message = "Dear maintainer, how can I help? :)"
     insert(:interest, project: project, message: message)
 
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Interests))
+    {:ok, _view, html} = live(conn, ~p"/messages/interests")
     assert html =~ project.name
     assert html =~ message
   end
@@ -90,7 +88,7 @@ defmodule AdoptopossWeb.MessagesLiveTest do
   test "/messages/interests shows an empty message if no interests where received yet", %{
     conn: conn
   } do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, MessagesLive.Interests))
+    {:ok, _view, html} = live(conn, ~p"/messages/interests")
     assert html =~ "You don’t have any messages here yet."
   end
 end

--- a/test/adoptoposs_web/live/project_live_test.exs
+++ b/test/adoptoposs_web/live/project_live_test.exs
@@ -3,30 +3,29 @@ defmodule AdoptopossWeb.ProjectLiveTest do
 
   import Adoptoposs.Factory
 
-  alias AdoptopossWeb.ProjectLive
   alias Adoptoposs.Submissions
   alias Adoptoposs.Submissions.Project
 
   test "disconnected mount requires authentication on project routes", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, ProjectLive))
+    conn = get(conn, ~p"/settings/projects")
     assert html_response(conn, 302)
     assert conn.halted
   end
 
   test "connected mount requires authentication on all project routes", %{conn: conn} do
-    path = Routes.live_path(conn, ProjectLive)
+    path = ~p"/settings/projects"
     assert {:error, {:redirect, %{to: "/"}}} = live(conn, path)
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /settings/projects shows the page when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, ProjectLive))
+    conn = get(conn, ~p"/settings/projects")
     assert html_response(conn, 200) =~ "Your Submitted Projects"
   end
 
   @tag login_as: "user123"
   test "connected mount of /settings/projects shows the page when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, _view, html} = live(conn, ~p"/settings/projects")
     assert html =~ "Your Submitted Projects"
   end
 
@@ -34,7 +33,7 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   test "editing a project", %{conn: conn, user: user} do
     project = insert(:project, user: user)
 
-    {:ok, view, html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, view, html} = live(conn, ~p"/settings/projects")
     assert html =~ project.name
     assert html =~ ~r/edit/i
     refute html =~ ~r/save/i
@@ -61,7 +60,7 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   test "unpublishing a project", %{conn: conn, user: user} do
     project = insert(:project, user: user, status: :published)
 
-    {:ok, view, html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, view, html} = live(conn, ~p"/settings/projects")
     assert html =~ project.name
     assert html =~ ~r/unpublish/i
 
@@ -74,7 +73,7 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   test "publishing a project", %{conn: conn, user: user} do
     project = insert(:project, user: user, status: :draft)
 
-    {:ok, view, html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, view, html} = live(conn, ~p"/settings/projects")
     assert html =~ project.name
     assert html =~ ~r/publish/i
     refute html =~ ~r/unpublish/i
@@ -87,7 +86,7 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   test "removing a project", %{conn: conn, user: user} do
     project = insert(:project, user: user)
 
-    {:ok, view, html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, view, html} = live(conn, ~p"/settings/projects")
     assert html =~ project.description
     html = render_submit(view, :remove, %{id: project.id})
     refute html =~ project.description
@@ -98,7 +97,7 @@ defmodule AdoptopossWeb.ProjectLiveTest do
   test "removing another user’s project is not possible", %{conn: conn} do
     project = insert(:project)
 
-    {:ok, view, _html} = live(conn, Routes.live_path(conn, ProjectLive))
+    {:ok, view, _html} = live(conn, ~p"/settings/projects")
     render_submit(view, :remove, %{id: project.id})
     assert Submissions.get_project!(project.id).id == project.id
   end

--- a/test/adoptoposs_web/live/repo_live_test.exs
+++ b/test/adoptoposs_web/live/repo_live_test.exs
@@ -4,25 +4,24 @@ defmodule AdoptopossWeb.RepoLiveTest do
   alias Adoptoposs.Tags.Tag
 
   test "disconnected mount of /settings/repos/:orga_id when logged out", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, AdoptopossWeb.RepoLive, "orga"))
+    conn = get(conn, ~p"/settings/repos/orga")
     assert html_response(conn, 302)
     assert conn.halted
   end
 
   test "connected mount of /settings/repos/:orga_id when logged out", %{conn: conn} do
-    assert {:error, {:redirect, %{to: "/"}}} =
-             live(conn, Routes.live_path(conn, AdoptopossWeb.RepoLive, "orga"))
+    assert {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/settings/repos/orga")
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /settings/repos/:orga_id when logged in", %{conn: conn, user: user} do
-    conn = get(conn, Routes.live_path(conn, AdoptopossWeb.RepoLive, user.username))
+    conn = get(conn, ~p"/settings/repos/#{user.username}")
     assert html_response(conn, 200) =~ "Submit Repo from"
   end
 
   @tag login_as: "user123"
   test "connected mount of /settings/repos/:orga_id when logged in", %{conn: conn, user: user} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, AdoptopossWeb.RepoLive, user.username))
+    {:ok, _view, html} = live(conn, ~p"/settings/repos/#{user.username}")
     assert html =~ "Submit Repo from"
   end
 
@@ -35,7 +34,7 @@ defmodule AdoptopossWeb.RepoLiveTest do
       insert(:tag, type: Tag.Language.type(), name: tag.name)
     end
 
-    {:ok, view, html} = live(conn, Routes.live_path(conn, AdoptopossWeb.RepoLive, user.username))
+    {:ok, view, html} = live(conn, ~p"/settings/repos/#{user.username}")
 
     for repo <- repos do
       assert html =~ repo.name

--- a/test/adoptoposs_web/live/settings_live_test.exs
+++ b/test/adoptoposs_web/live/settings_live_test.exs
@@ -1,28 +1,27 @@
 defmodule AdoptopossWeb.SettingsLiveTest do
   use AdoptopossWeb.LiveCase
 
-  alias AdoptopossWeb.SettingsLive
   alias Adoptoposs.Accounts.Settings
 
   test "disconnected mount of /settings when logged out", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, SettingsLive))
+    conn = get(conn, ~p"/settings")
     assert html_response(conn, 302)
     assert conn.halted
   end
 
   test "connected mount of /settings when logged out", %{conn: conn} do
-    {:error, {:redirect, %{to: "/"}}} = live(conn, Routes.live_path(conn, SettingsLive))
+    {:error, {:redirect, %{to: "/"}}} = live(conn, ~p"/settings")
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /settings when logged in", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, SettingsLive))
+    conn = get(conn, ~p"/settings")
     assert html_response(conn, 200) =~ "Settings"
   end
 
   @tag login_as: "user123"
   test "connected mount of /settings when logged in", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, SettingsLive))
+    {:ok, _view, html} = live(conn, ~p"/settings")
     assert html =~ "Settings"
   end
 
@@ -30,7 +29,7 @@ defmodule AdoptopossWeb.SettingsLiveTest do
     @tag login_as: "user123"
     test "adding a tag", %{conn: conn} do
       tag = insert(:tag, type: "language")
-      {:ok, view, _html} = live(conn, Routes.live_path(conn, SettingsLive))
+      {:ok, view, _html} = live(conn, ~p"/settings")
 
       html = render_change(view, :search_tags, %{q: tag.name})
       assert html =~ "Add #{tag.name}"
@@ -45,7 +44,7 @@ defmodule AdoptopossWeb.SettingsLiveTest do
       tag = insert(:tag, type: "language")
       insert(:tag_subscription, user: user, tag: tag)
 
-      {:ok, view, html} = live(conn, Routes.live_path(conn, SettingsLive))
+      {:ok, view, html} = live(conn, ~p"/settings")
       assert html =~ "Remove #{tag.name}"
 
       html = render_change(view, :search_tags, %{q: tag.name})
@@ -59,7 +58,7 @@ defmodule AdoptopossWeb.SettingsLiveTest do
     test "removing a tag", %{conn: conn, user: user} do
       tag_subscription = insert(:tag_subscription, user: user)
 
-      {:ok, view, html} = live(conn, Routes.live_path(conn, SettingsLive))
+      {:ok, view, html} = live(conn, ~p"/settings")
       assert html =~ "Remove #{tag_subscription.tag.name}"
 
       html = render_click(view, :remove_tag, %{tag_subscription_id: tag_subscription.id})
@@ -70,7 +69,7 @@ defmodule AdoptopossWeb.SettingsLiveTest do
   describe "notifications" do
     @tag login_as: "user123"
     test "changing email_when_contacted", %{conn: conn} do
-      {:ok, view, html} = live(conn, Routes.live_path(conn, SettingsLive))
+      {:ok, view, html} = live(conn, ~p"/settings")
 
       valid_values = Settings.email_when_contacted_values()
       assert radio_button_checked?(html, List.first(valid_values))
@@ -88,7 +87,7 @@ defmodule AdoptopossWeb.SettingsLiveTest do
 
     @tag login_as: "user123"
     test "changing email_project_recommendations", %{conn: conn} do
-      {:ok, view, html} = live(conn, Routes.live_path(conn, SettingsLive))
+      {:ok, view, html} = live(conn, ~p"/settings")
 
       valid_values = Settings.email_project_recommendations_values()
       assert radio_button_checked?(html, List.first(valid_values))

--- a/test/adoptoposs_web/live/sharing_live_test.exs
+++ b/test/adoptoposs_web/live/sharing_live_test.exs
@@ -3,53 +3,51 @@ defmodule AdoptopossWeb.SharingLiveTest do
 
   import Adoptoposs.Factory
 
-  alias AdoptopossWeb.SharingLive
-
   test "disconnected mount of /projects/:uuid when logged out", %{conn: conn} do
     project = insert(:project)
-    conn = get(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    conn = get(conn, ~p"/projects/#{project.uuid}")
     assert html_response(conn, 200) =~ "#{project.repo_owner}/#{project.name}"
   end
 
   @tag login_as: "user123"
   test "disconnected mount of /projects/:uuid when logged in", %{conn: conn} do
     project = insert(:project)
-    conn = get(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    conn = get(conn, ~p"/projects/#{project.uuid}")
     assert html_response(conn, 200) =~ "#{project.repo_owner}/#{project.name}"
   end
 
   test "disconnected mount of /projects/:uuid with invalid uuid", %{conn: conn} do
-    conn = get(conn, Routes.live_path(conn, SharingLive, "invalid-uuid"))
+    conn = get(conn, ~p"/projects/invalid-uuid")
     assert html_response(conn, 200) =~ "The project is not available"
   end
 
   test "disconnected mount of /projects/:uuid with not published project", %{conn: conn} do
     project = insert(:project, status: :draft)
-    conn = get(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    conn = get(conn, ~p"/projects/#{project.uuid}")
     assert html_response(conn, 200) =~ "The project is not available"
   end
 
   test "connected mount of /projects/:uuid when logged out", %{conn: conn} do
     project = insert(:project)
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    {:ok, _view, html} = live(conn, ~p"/projects/#{project.uuid}")
     assert html =~ "#{project.repo_owner}/#{project.name}"
   end
 
   @tag login_as: "user123"
   test "connected mount of /projects/:uuid when logged in", %{conn: conn} do
     project = insert(:project)
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    {:ok, _view, html} = live(conn, ~p"/projects/#{project.uuid}")
     assert html =~ "#{project.repo_owner}/#{project.name}"
   end
 
   test "connected mount of /projects/:uuid with invalid uuid", %{conn: conn} do
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, "invalid-uuid"))
+    {:ok, _view, html} = live(conn, ~p"/projects/invalid-uuid")
     assert html =~ "The project is not available"
   end
 
   test "connected mount of /projects/:uuid for not published project", %{conn: conn} do
     project = insert(:project, status: :draft)
-    {:ok, _view, html} = live(conn, Routes.live_path(conn, SharingLive, project.uuid))
+    {:ok, _view, html} = live(conn, ~p"/projects/#{project.uuid}")
     assert html =~ "The project is not available"
   end
 end

--- a/test/adoptoposs_web/plugs/require_login_test.exs
+++ b/test/adoptoposs_web/plugs/require_login_test.exs
@@ -3,7 +3,6 @@ defmodule AdoptoppossWeb.Plugs.RequireLoginTest do
 
   alias Adoptoposs.Accounts.User
   alias AdoptopossWeb.Plugs.RequireLogin
-  alias AdoptopossWeb.LandingPageLive
 
   setup(%{conn: conn}) do
     conn =
@@ -17,7 +16,7 @@ defmodule AdoptoppossWeb.Plugs.RequireLoginTest do
   test "user is redirected if current_user is not assigned", %{conn: conn} do
     conn = require_login(conn)
 
-    assert redirected_to(conn) == Routes.live_path(conn, LandingPageLive)
+    assert redirected_to(conn) == ~p"/"
     assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "You need to log in"
     assert %{halted: true} = conn
   end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -23,6 +23,8 @@ defmodule AdoptopossWeb.ConnCase do
       import AdoptopossWeb.ConnCase
       import Adoptoposs.Factory
 
+      use AdoptopossWeb, :verified_routes
+
       alias AdoptopossWeb.Router.Helpers, as: Routes
 
       # The default endpoint for testing


### PR DESCRIPTION
Use verified routes (`~p"…"`) instead of `Routes.` helpers.

(This also fixes a small inconsistency with the presence of query params on the explore page.)